### PR TITLE
Refactor: Remove 161-line code clone between DeprecatedMailStorageScr…

### DIFF
--- a/cpd-results.txt
+++ b/cpd-results.txt
@@ -1,0 +1,11932 @@
+Found a 164 line (1152 tokens) duplication in the following files: 
+Starting at line 83 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-filters/xwiki-platform-legacy-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/LegacyDefaultNotificationFilterManagerTest.java
+Starting at line 79 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterManagerTest.java
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        testUser = new DocumentReference("wiki", "test", "user");
+
+        // Set a default comportment for the wikiDescriptorManager
+        when(wikiDescriptorManager.getMainWikiId()).thenReturn("wiki");
+        when(wikiDescriptorManager.getCurrentWikiId()).thenReturn("currentWikiId");
+        when(wikiDescriptorManager.getAllIds()).thenReturn(Arrays.asList("wiki", "currentWikiId"));
+    }
+
+    @Test
+    void getAllNotificationsFiltersWithSubWiki() throws Exception
+    {
+        NotificationFilter fakeFilter1 = mock(NotificationFilter.class);
+        NotificationFilter fakeFilter2 = mock(NotificationFilter.class);
+
+        when(wikiDescriptorManager.getMainWikiId()).thenReturn("somethingElseThanwiki");
+
+        when(componentManager.getInstanceList(NotificationFilter.class))
+                .thenReturn(Arrays.asList(fakeFilter1, fakeFilter2));
+
+        Collection<NotificationFilter> filters = this.filterManager.getAllFilters(testUser, false);
+
+        assertEquals(2, filters.size());
+        assertTrue(filters.contains(fakeFilter1));
+        assertTrue(filters.contains(fakeFilter2));
+    }
+
+    @Test
+    void getAllFiltersWithMainWiki() throws Exception
+    {
+        NotificationFilter fakeFilter1 = mock(NotificationFilter.class);
+
+        when(componentManager.getInstanceMap(NotificationFilter.class))
+                .thenReturn(Collections.singletonMap("1", fakeFilter1));
+
+        Collection<NotificationFilter> filters = this.filterManager.getAllFilters(testUser, false);
+
+        assertEquals(1, filters.size());
+        assertTrue(filters.contains(fakeFilter1));
+    }
+
+    @Test
+    void getAllFiltersForWiki() throws Exception
+    {
+        NotificationFilter fakeFilter1 = mock(NotificationFilter.class);
+        NotificationFilter fakeFilter2 = mock(NotificationFilter.class);
+
+        WikiReference currentWiki = new WikiReference("current");
+        when(wikiDescriptorManager.getCurrentWikiReference()).thenReturn(currentWiki);
+
+        WikiReference argumentWiki = new WikiReference("foo");
+
+        when(componentManager.getInstanceList(NotificationFilter.class))
+            .thenReturn(Arrays.asList(fakeFilter1, fakeFilter2));
+
+        Collection<NotificationFilter> filters = this.filterManager.getAllFilters(argumentWiki);
+
+        assertEquals(2, filters.size());
+        assertTrue(filters.contains(fakeFilter1));
+        assertTrue(filters.contains(fakeFilter2));
+        verify(this.modelContext).setCurrentEntityReference(argumentWiki);
+        verify(this.modelContext).setCurrentEntityReference(currentWiki);
+    }
+
+    @Test
+    void getAllFiltersWithOneDisabledFilter() throws Exception
+    {
+        SystemUserNotificationFilter disabledFilter = mock(SystemUserNotificationFilter.class);
+
+        when(componentManager.getInstanceMap(NotificationFilter.class))
+                .thenReturn(Collections.singletonMap("1", disabledFilter));
+
+        when(disabledFilter.getName()).thenReturn(SystemUserNotificationFilter.FILTER_NAME);
+        Map<String, Boolean> filterActivations = new HashMap<>();
+        filterActivations.put(SystemUserNotificationFilter.FILTER_NAME, false);
+
+        Collection<NotificationFilter> filters = this.filterManager.getEnabledFilters(
+                this.filterManager.getAllFilters(testUser, true), filterActivations).collect(Collectors.toList());
+
+        assertEquals(0, filters.size());
+    }
+
+    @Test
+    void getFiltersWithMatchingFilters() throws Exception
+    {
+        NotificationFilter fakeFilter1 = mock(NotificationFilter.class);
+
+        NotificationPreference preference = mock(NotificationPreference.class);
+
+        when(fakeFilter1.matchesPreference(preference)).thenReturn(true);
+
+        Collection<NotificationFilter> filters = this.filterManager.getFiltersRelatedToNotificationPreference(
+                Arrays.asList(fakeFilter1), preference).collect(Collectors.toList());
+
+        assertEquals(1, filters.size());
+        assertTrue(filters.contains(fakeFilter1));
+    }
+
+    @Test
+    void getFiltersWithOneBadFilter() throws Exception
+    {
+        NotificationFilter fakeFilter1 = mock(NotificationFilter.class);
+
+        NotificationPreference preference = mock(NotificationPreference.class);
+
+        when(fakeFilter1.matchesPreference(preference)).thenReturn(false);
+
+        Collection<NotificationFilter> filters = this.filterManager
+            .getFiltersRelatedToNotificationPreference(Arrays.asList(fakeFilter1), preference)
+            .collect(Collectors.toList());
+
+        assertEquals(0, filters.size());
+    }
+
+    @Test
+    void getFiltersWithSpecificFilteringPhase() throws Exception
+    {
+        NotificationFilter filter1 = mock(NotificationFilter.class);
+        NotificationFilter filter2 = mock(NotificationFilter.class);
+        NotificationFilter filter3 = mock(NotificationFilter.class);
+        NotificationFilter filter4 = mock(NotificationFilter.class);
+        NotificationFilter filter5 = mock(NotificationFilter.class);
+        NotificationFilter filter6 = mock(NotificationFilter.class);
+        NotificationFilter filter7 = mock(NotificationFilter.class);
+
+        when(filter1.getName()).thenReturn("filter1");
+        when(filter2.getName()).thenReturn("filter2");
+        when(filter3.getName()).thenReturn("filter3");
+        when(filter4.getName()).thenReturn("filter4");
+        when(filter5.getName()).thenReturn("filter5");
+        when(filter6.getName()).thenReturn("filter6");
+        when(filter7.getName()).thenReturn("filter7");
+
+        Map<String, ToggleableNotificationFilterActivation> filterActivations = new HashMap<>();
+        filterActivations.put("filter1", new ToggleableNotificationFilterActivation("filter1", true, null, -1));
+        filterActivations.put("filter2", new ToggleableNotificationFilterActivation("filter2", false, null, -1));
+        filterActivations.put("filter3", new ToggleableNotificationFilterActivation("filter3", true, null, -1));
+        filterActivations.put("filter4", new ToggleableNotificationFilterActivation("filter4", false, null, -1));
+        filterActivations.put("filter5", new ToggleableNotificationFilterActivation("filter5", true, null, -1));
+        filterActivations.put("filter6", new ToggleableNotificationFilterActivation("filter6", false, null, -1));
+        // We don't put filter7 so it should default as being considered activated
+
+        when(this.filterPreferencesModelBridge.getToggleableFilterActivations(testUser)).thenReturn(filterActivations);
+        when(filter1.getFilteringPhases())
+            .thenReturn(NotificationFilter.SUPPORT_ONLY_PRE_FILTERING_PHASE);
+        when(filter2.getFilteringPhases())
+            .thenReturn(NotificationFilter.SUPPORT_ONLY_PRE_FILTERING_PHASE);
+        when(filter3.getFilteringPhases())
+            .thenReturn(NotificationFilter.SUPPORT_ONLY_POST_FILTERING_PHASE);
+        when(filter4.getFilteringPhases())
+            .thenReturn(NotificationFilter.SUPPORT_ONLY_POST_FILTERING_PHASE);
+        when(filter5.getFilteringPhases())
+            .thenReturn(NotificationFilter.SUPPORT_BOTH_FILTERING_PHASE);
+        when(filter6.getFilteringPhases())
+            .thenReturn(NotificationFilter.SUPPORT_BOTH_FILTERING_PHASE);
+        when(filter7.getFilteringPhases())
+            .thenReturn(NotificationFilter.SUPPORT_BOTH_FILTERING_PHASE);
+
+        // Using subwiki so we manipulate a set instead of a map
+        when(wikiDescriptorManager.getMainWikiId()).thenReturn("somethingElseThanwiki");
+        when(componentManager.getInstanceList(NotificationFilter.class))
+            .thenReturn(Arrays.asList(filter1, filter2, filter3, filter4, filter5, filter6, filter7));
+
+=====================================================================
+Found a 115 line (719 tokens) duplication in the following files: 
+Starting at line 212 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
+Starting at line 390 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
+
+        when(this.filterPreferencesModelBridge.getToggleableFilterActivations(prefReference)).thenReturn(Map.of(
+            filter4Name, activationFilter4,
+            filter5Name, activationFilter5,
+            filter7Name, activationFilter7
+        ));
+
+        when(filter2.isEnabledByDefault()).thenReturn(true);
+        when(filter6.isEnabledByDefault()).thenReturn(false);
+
+        when(filter4.isEnabledByDefault()).thenReturn(true);
+        when(filter5.isEnabledByDefault()).thenReturn(false);
+        when(filter7.isEnabledByDefault()).thenReturn(false);
+
+        when(activationFilter4.isEnabled()).thenReturn(false);
+        when(activationFilter5.isEnabled()).thenReturn(true);
+        when(activationFilter7.isEnabled()).thenReturn(false);
+
+        when(activationFilter4.getObjectNumber()).thenReturn(-1);
+        when(activationFilter5.getObjectNumber()).thenReturn(2);
+        when(activationFilter7.getObjectNumber()).thenReturn(14);
+
+        // Get all info to start
+        when(query.getOffset()).thenReturn(0L);
+        when(query.getLimit()).thenReturn(10);
+
+        when(this.translationHelper.getTranslationWithPrefix(eq("notifications.filters.name."), anyString()))
+            .thenAnswer(invocationOnMock -> "Name:" + invocationOnMock.getArgument(1));
+        when(this.translationHelper.getTranslationWithPrefix(eq("notifications.filters.description."), anyString()))
+            .thenAnswer(invocationOnMock -> "Description " + invocationOnMock.getArgument(1));
+        when(this.translationHelper.getFormatTranslation(any()))
+            .thenAnswer(invocationOnMock -> "Format " + invocationOnMock.getArgument(0));
+
+        Map<String, Object> dataFilter2 = Map.of(
+            "name", "Name:" + filter2Name,
+            "filterDescription", "Description " + filter2Name,
+            "notificationFormats", Map.of(
+                "extraClass", "list-unstyled",
+                "items", List.of("Format ALERT", "Format EMAIL")
+            ),
+            "isEnabled_data", Map.of(
+                "objectNumber", "",
+                "filterName", filter2Name
+            ),
+            "isEnabled_checked", true
+        );
+
+        Map<String, Object> dataFilter4 = Map.of(
+            "name", "Name:" + filter4Name,
+            "filterDescription", "Description " + filter4Name,
+            "notificationFormats", Map.of(
+                "extraClass", "list-unstyled",
+                "items", List.of()
+            ),
+            "isEnabled_data", Map.of(
+                "objectNumber", "",
+                "filterName", filter4Name
+            ),
+            "isEnabled_checked", false
+        );
+
+        Map<String, Object> dataFilter5 = Map.of(
+            "name", "Name:" + filter5Name,
+            "filterDescription", "Description " + filter5Name,
+            "notificationFormats", Map.of(
+                "extraClass", "list-unstyled",
+                "items", List.of("Format ALERT")
+            ),
+            "isEnabled_data", Map.of(
+                "objectNumber", "2",
+                "filterName", filter5Name
+            ),
+            "isEnabled_checked", true
+        );
+
+        Map<String, Object> dataFilter6 = Map.of(
+            "name", "Name:" + filter6Name,
+            "filterDescription", "Description " + filter6Name,
+            "notificationFormats", Map.of(
+                "extraClass", "list-unstyled",
+                "items", List.of("Format EMAIL")
+            ),
+            "isEnabled_data", Map.of(
+                "objectNumber", "",
+                "filterName", filter6Name
+            ),
+            "isEnabled_checked", false
+        );
+
+        Map<String, Object> dataFilter7 = Map.of(
+            "name", "Name:" + filter7Name,
+            "filterDescription", "Description " + filter7Name,
+            "notificationFormats", Map.of(
+                "extraClass", "list-unstyled",
+                "items", List.of("Format ALERT", "Format EMAIL")
+            ),
+            "isEnabled_data", Map.of(
+                "objectNumber", "14",
+                "filterName", filter7Name
+            ),
+            "isEnabled_checked", false
+        );
+
+        LiveData liveData = new LiveData();
+        liveData.setCount(5L);
+        liveData.getEntries().addAll(List.of(dataFilter2, dataFilter4, dataFilter5, dataFilter6, dataFilter7));
+        assertEquals(liveData, this.entryStore.get(query));
+
+        when(query.getOffset()).thenReturn(2L);
+        when(query.getLimit()).thenReturn(2);
+
+        liveData = new LiveData();
+        liveData.setCount(5L);
+        liveData.getEntries().addAll(List.of(dataFilter5, dataFilter6));
+        assertEquals(liveData, this.entryStore.get(query));
+    }
+
+=====================================================================
+Found a 63 line (629 tokens) duplication in the following files: 
+Starting at line 213 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 323 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+    void getFilterPreferencesFilterNoSort() throws QueryException, LiveDataException
+    {
+        String owner = "xwiki:XWiki.Foo";
+        String wikiName = "foo";
+        Long offset = 3L;
+        int limit = 12;
+        WikiReference wikiReference = new WikiReference(wikiName);
+
+        LiveDataQuery ldQuery = mock(LiveDataQuery.class);
+        when(ldQuery.getOffset()).thenReturn(offset);
+        when(ldQuery.getLimit()).thenReturn(limit);
+
+        LiveDataQuery.Filter filter1 = mock(LiveDataQuery.Filter.class, "filter1");
+        when(filter1.getProperty()).thenReturn("location");
+        when(filter1.isMatchAll()).thenReturn(false);
+        LiveDataQuery.Constraint filter1Constraint1 = mock(LiveDataQuery.Constraint.class, "filter1Constraint1");
+        when(filter1Constraint1.getOperator()).thenReturn("startsWith");
+        when(filter1Constraint1.getValue()).thenReturn("foo");
+        LiveDataQuery.Constraint filter1Constraint2 = mock(LiveDataQuery.Constraint.class, "filter1Constraint2");
+        when(filter1Constraint2.getOperator()).thenReturn("contains");
+        when(filter1Constraint2.getValue()).thenReturn("bar");
+        LiveDataQuery.Constraint filter1Constraint3 = mock(LiveDataQuery.Constraint.class, "filter1Constraint3");
+        when(filter1Constraint3.getOperator()).thenReturn("equals");
+        when(filter1Constraint3.getValue()).thenReturn("buz");
+        when(filter1.getConstraints()).thenReturn(List.of(filter1Constraint1, filter1Constraint2, filter1Constraint3));
+
+        LiveDataQuery.Filter filter2 = mock(LiveDataQuery.Filter.class, "filter2");
+        when(filter2.getProperty()).thenReturn("eventTypes");
+        LiveDataQuery.Constraint filter2Constraint = mock(LiveDataQuery.Constraint.class, "filter2Constraint");
+        when(filter2Constraint.getOperator()).thenReturn("equals");
+        when(filter2Constraint.getValue()).thenReturn("__ALL_EVENTS__");
+        when(filter2.getConstraints()).thenReturn(List.of(filter2Constraint));
+
+        LiveDataQuery.Filter filter3 = mock(LiveDataQuery.Filter.class, "filter3");
+        when(filter3.getProperty()).thenReturn("isEnabled");
+        LiveDataQuery.Constraint filter3Constraint = mock(LiveDataQuery.Constraint.class, "filter3Constraint");
+        when(filter3Constraint.getOperator()).thenReturn("equals");
+        when(filter3Constraint.getValue()).thenReturn("true");
+        when(filter3.getConstraints()).thenReturn(List.of(filter3Constraint));
+
+        LiveDataQuery.Filter filter4 = mock(LiveDataQuery.Filter.class, "filter4");
+        when(filter4.getProperty()).thenReturn("scope");
+        LiveDataQuery.Constraint filter4Constraint = mock(LiveDataQuery.Constraint.class, "filter4Constraint");
+        when(filter4Constraint.getOperator()).thenReturn("equals");
+        when(filter4Constraint.getValue()).thenReturn("PAGE");
+        when(filter4.getConstraints()).thenReturn(List.of(filter4Constraint));
+
+        LiveDataQuery.Filter filter5 = mock(LiveDataQuery.Filter.class, "filter5");
+        when(filter5.getProperty()).thenReturn("filterType");
+        LiveDataQuery.Constraint filter5Constraint = mock(LiveDataQuery.Constraint.class, "filter5Constraint");
+        when(filter5Constraint.getOperator()).thenReturn("equals");
+        when(filter5Constraint.getValue()).thenReturn("INCLUSIVE");
+        when(filter5.getConstraints()).thenReturn(List.of(filter5Constraint));
+
+        when(ldQuery.getFilters()).thenReturn(List.of(
+            filter1,
+            filter2,
+            filter3,
+            filter4,
+            filter5
+        ));
+
+        String queryString = "select nfp from DefaultNotificationFilterPreference nfp where owner = :owner "
+
+=====================================================================
+Found a 61 line (626 tokens) duplication in the following files: 
+Starting at line 213 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 426 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 552 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+    void getFilterPreferencesFilterNoSort() throws QueryException, LiveDataException
+    {
+        String owner = "xwiki:XWiki.Foo";
+        String wikiName = "foo";
+        Long offset = 3L;
+        int limit = 12;
+        WikiReference wikiReference = new WikiReference(wikiName);
+
+        LiveDataQuery ldQuery = mock(LiveDataQuery.class);
+        when(ldQuery.getOffset()).thenReturn(offset);
+        when(ldQuery.getLimit()).thenReturn(limit);
+
+        LiveDataQuery.Filter filter1 = mock(LiveDataQuery.Filter.class, "filter1");
+        when(filter1.getProperty()).thenReturn("location");
+        when(filter1.isMatchAll()).thenReturn(false);
+        LiveDataQuery.Constraint filter1Constraint1 = mock(LiveDataQuery.Constraint.class, "filter1Constraint1");
+        when(filter1Constraint1.getOperator()).thenReturn("startsWith");
+        when(filter1Constraint1.getValue()).thenReturn("foo");
+        LiveDataQuery.Constraint filter1Constraint2 = mock(LiveDataQuery.Constraint.class, "filter1Constraint2");
+        when(filter1Constraint2.getOperator()).thenReturn("contains");
+        when(filter1Constraint2.getValue()).thenReturn("bar");
+        LiveDataQuery.Constraint filter1Constraint3 = mock(LiveDataQuery.Constraint.class, "filter1Constraint3");
+        when(filter1Constraint3.getOperator()).thenReturn("equals");
+        when(filter1Constraint3.getValue()).thenReturn("buz");
+        when(filter1.getConstraints()).thenReturn(List.of(filter1Constraint1, filter1Constraint2, filter1Constraint3));
+
+        LiveDataQuery.Filter filter2 = mock(LiveDataQuery.Filter.class, "filter2");
+        when(filter2.getProperty()).thenReturn("eventTypes");
+        LiveDataQuery.Constraint filter2Constraint = mock(LiveDataQuery.Constraint.class, "filter2Constraint");
+        when(filter2Constraint.getOperator()).thenReturn("equals");
+        when(filter2Constraint.getValue()).thenReturn("__ALL_EVENTS__");
+        when(filter2.getConstraints()).thenReturn(List.of(filter2Constraint));
+
+        LiveDataQuery.Filter filter3 = mock(LiveDataQuery.Filter.class, "filter3");
+        when(filter3.getProperty()).thenReturn("isEnabled");
+        LiveDataQuery.Constraint filter3Constraint = mock(LiveDataQuery.Constraint.class, "filter3Constraint");
+        when(filter3Constraint.getOperator()).thenReturn("equals");
+        when(filter3Constraint.getValue()).thenReturn("true");
+        when(filter3.getConstraints()).thenReturn(List.of(filter3Constraint));
+
+        LiveDataQuery.Filter filter4 = mock(LiveDataQuery.Filter.class, "filter4");
+        when(filter4.getProperty()).thenReturn("scope");
+        LiveDataQuery.Constraint filter4Constraint = mock(LiveDataQuery.Constraint.class, "filter4Constraint");
+        when(filter4Constraint.getOperator()).thenReturn("equals");
+        when(filter4Constraint.getValue()).thenReturn("PAGE");
+        when(filter4.getConstraints()).thenReturn(List.of(filter4Constraint));
+
+        LiveDataQuery.Filter filter5 = mock(LiveDataQuery.Filter.class, "filter5");
+        when(filter5.getProperty()).thenReturn("filterType");
+        LiveDataQuery.Constraint filter5Constraint = mock(LiveDataQuery.Constraint.class, "filter5Constraint");
+        when(filter5Constraint.getOperator()).thenReturn("equals");
+        when(filter5Constraint.getValue()).thenReturn("INCLUSIVE");
+        when(filter5.getConstraints()).thenReturn(List.of(filter5Constraint));
+
+        when(ldQuery.getFilters()).thenReturn(List.of(
+            filter1,
+            filter2,
+            filter3,
+            filter4,
+            filter5
+        ));
+
+=====================================================================
+Found a 84 line (599 tokens) duplication in the following files: 
+Starting at line 1157 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+Starting at line 1266 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+
+        List<String> stringTestDiff = objectEntityDiff.getDiff("stringTest");
+        assertEquals(2, stringTestDiff.size());
+        assertEquals("@@ -1,0 +1,1 @@", stringTestDiff.get(0));
+        assertEquals("+anothervalue", stringTestDiff.get(1));
+
+        // diff 1.1 -> 4.1
+        changesPane.clickPreviousToVersion();
+        changesPane = new ChangesPane();
+        rawChanges = changesPane.getRawChanges();
+        contentDiff = rawChanges.getEntityDiff("Page properties").getDiff("Content");
+        assertEquals(3, contentDiff.size());
+        assertEquals("@@ -1,1 +1,1 @@", contentDiff.get(0));
+        assertEquals("-Some content", contentDiff.get(1));
+        assertEquals("+Some content<ins> 2</ins>", contentDiff.get(2));
+
+        objectEntityDiff = rawChanges.getEntityDiff(objectIdInDiff);
+        assertTrue(objectEntityDiff.isDiffObfuscated("mypass"));
+        stringTestDiff = objectEntityDiff.getDiff("stringTest");
+        assertEquals(2, stringTestDiff.size());
+        assertEquals("@@ -1,0 +1,1 @@", stringTestDiff.get(0));
+        assertEquals("+anothervalue", stringTestDiff.get(1));
+
+        // diff 1.1 -> 3.1
+        changesPane.clickPreviousToVersion();
+        changesPane = new ChangesPane();
+        rawChanges = changesPane.getRawChanges();
+        contentDiff = rawChanges.getEntityDiff("Page properties").getDiff("Content");
+        assertEquals(3, contentDiff.size());
+        assertEquals("@@ -1,1 +1,1 @@", contentDiff.get(0));
+        assertEquals("-Some content", contentDiff.get(1));
+        assertEquals("+Some content<ins> 2</ins>", contentDiff.get(2));
+
+        objectEntityDiff = rawChanges.getEntityDiff(objectIdInDiff);
+        assertTrue(objectEntityDiff.isDiffObfuscated("mypass"));
+        stringTestDiff = objectEntityDiff.getDiff("stringTest");
+        assertEquals(2, stringTestDiff.size());
+        assertEquals("@@ -1,0 +1,1 @@", stringTestDiff.get(0));
+        assertEquals("+myvalue", stringTestDiff.get(1));
+
+        // diff 1.1 -> 2.1
+        changesPane.clickPreviousToVersion();
+        changesPane = new ChangesPane();
+        rawChanges = changesPane.getRawChanges();
+
+        objectEntityDiff = rawChanges.getEntityDiff(objectIdInDiff);
+        assertTrue(objectEntityDiff.isDiffObfuscated("mypass"));
+        stringTestDiff = objectEntityDiff.getDiff("stringTest");
+        assertEquals(2, stringTestDiff.size());
+        assertEquals("@@ -1,0 +1,1 @@", stringTestDiff.get(0));
+        assertEquals("+myvalue", stringTestDiff.get(1));
+
+        // diff 2.1 -> 2.1
+        changesPane.clickNextFromVersion();
+        changesPane = new ChangesPane();
+        assertTrue(changesPane.getRawChanges().hasNoChanges());
+
+        // diff 2.1 -> 3.1
+        changesPane.clickNextToVersion();
+        changesPane = new ChangesPane();
+        rawChanges = changesPane.getRawChanges();
+        assertTrue(rawChanges.getDiffSummary().getModifiedObjects().isEmpty());
+
+        contentDiff = rawChanges.getEntityDiff("Page properties").getDiff("Content");
+        assertEquals(3, contentDiff.size());
+        assertEquals("@@ -1,1 +1,1 @@", contentDiff.get(0));
+        assertEquals("-Some content", contentDiff.get(1));
+        assertEquals("+Some content<ins> 2</ins>", contentDiff.get(2));
+
+        // diff 3.1 -> 3.1
+        changesPane.clickNextFromVersion();
+        changesPane = new ChangesPane();
+        assertTrue(changesPane.getRawChanges().hasNoChanges());
+
+        // diff 3.1 -> 4.1
+        changesPane.clickNextToVersion();
+        changesPane = new ChangesPane();
+        rawChanges = changesPane.getRawChanges();
+        objectEntityDiff = rawChanges.getEntityDiff(objectIdInDiff);
+        assertTrue(objectEntityDiff.isDiffObfuscated("mypass"));
+        stringTestDiff = objectEntityDiff.getDiff("stringTest");
+        assertEquals(3, stringTestDiff.size());
+        assertEquals("@@ -1,1 +1,1 @@", stringTestDiff.get(0));
+        assertEquals("-<del>my</del>value", stringTestDiff.get(1));
+        assertEquals("+<ins>another</ins>value", stringTestDiff.get(2));
+
+=====================================================================
+Found a 161 line (502 tokens) duplication in the following files: 
+Starting at line 156 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-storage/src/main/java/org/xwiki/mail/script/DeprecatedMailStorageScriptService.java
+Starting at line 157 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/script/MailStorageScriptService.java
+
+    }
+
+    /**
+     * Load message status for the message matching the given message Id.
+     *
+     * @param uniqueMessageId the unique identifier of the message.
+     * @return the loaded {@link org.xwiki.mail.MailStatus} or null if not allowed or an error happens
+     * @since 7.1M2
+     */
+    public MailStatus load(String uniqueMessageId)
+    {
+        // Note: We don't need to check permissions since the caller already needs to know the message id
+        // to be able to call this method and for it to have any effect.
+
+        try {
+            return this.mailStatusStore.load(uniqueMessageId);
+        } catch (MailStoreException e) {
+            // Save the exception for reporting through the script services's getLastError() API
+            setError(e);
+            return null;
+        }
+    }
+
+    /**
+     * Loads all message statuses matching the passed filters.
+     *
+     * @param filterMap the map of Mail Status parameters to match (e.g. "status", "wiki", "batchId", etc)
+     * @param offset the number of rows to skip (0 means don't skip any row)
+     * @param count the number of rows to return. If 0 then all rows are returned
+     * @param sortField the name of the field used to order returned status
+     * @param sortAscending when true, sort is done in ascending order of sortField, else in descending order
+     * @return the loaded {@link org.xwiki.mail.MailStatus} instances or null if not allowed or an error happens
+     * @since 7.1M2
+     */
+    public List<MailStatus> load(Map<String, Object> filterMap, int offset, int count, String sortField,
+        boolean sortAscending)
+    {
+        // Only admins are allowed
+        if (this.authorizationManager.hasAccess(Right.ADMIN)) {
+            try {
+                return this.mailStatusStore.load(normalizeFilterMap(filterMap), offset, count,
+                    sortField, sortAscending);
+            } catch (MailStoreException e) {
+                // Save the exception for reporting through the script services's getLastError() API
+                setError(e);
+                return null;
+            }
+        } else {
+            // Save the exception for reporting through the script services's getLastError() API
+            setError(new MailStoreException("You need Admin rights to load mail statuses"));
+            return null;
+        }
+    }
+
+    /**
+     * Count the number of message statuses matching the passed filters.
+     *
+     * @param filterMap the map of Mail Status parameters to match (e.g. "status", "wiki", "batchId", etc)
+     * @return the number of mail statuses or 0 if not allowed or an error happens
+     */
+    public long count(Map<String, Object> filterMap)
+    {
+        // Only admins are allowed
+        if (this.authorizationManager.hasAccess(Right.ADMIN)) {
+            try {
+                return this.mailStatusStore.count(normalizeFilterMap(filterMap));
+            } catch (MailStoreException e) {
+                // Save the exception for reporting through the script services's getLastError() API
+                setError(e);
+                return 0;
+            }
+        } else {
+            // Save the exception for reporting through the script services's getLastError() API
+            setError(new MailStoreException("You need Admin rights to count mail statuses"));
+            return 0;
+        }
+    }
+
+    /**
+     * Delete all messages from a batch (both the statuses in the database and the serialized messages on the file
+     * system).
+     *
+     * @param batchId the id of the batch for which to delete all messages
+     */
+    public void delete(String batchId)
+    {
+        // Note: We don't need to check permissions since the call to load() will do that anyway.
+
+        Map<String, Object> filterMap = Collections.<String, Object>singletonMap("batchId", batchId);
+        List<MailStatus> statuses = load(filterMap, 0, 0, null, false);
+        if (statuses != null) {
+            for (MailStatus status : statuses) {
+                delete(batchId, status.getMessageId());
+            }
+        }
+    }
+
+    /**
+     * Delete all messages having a status in the database and their serialized messages on the file system.
+     *
+     * @since 9.4RC1
+     */
+    public void deleteAll()
+    {
+        // Note: We don't need to check permissions since the call to load() will do that anyway.
+
+        List<MailStatus> statuses = load(Collections.emptyMap(), 0, 0, null, false);
+        if (statuses != null) {
+            for (MailStatus status : statuses) {
+                delete(status.getBatchId(), status.getMessageId());
+            }
+        }
+    }
+
+    /**
+     * Delete a message (both the status in the database and the serialized messages on the file system).
+     *
+     * @param batchId the id of the batch for the message to delete
+     * @param uniqueMessageId the unique id of the message to delete
+     */
+    public void delete(String batchId, String uniqueMessageId)
+    {
+        // Note: We don't need to check permissions since the caller already needs to know the batch id and mail id
+        // to be able to call this method and for it to have any effect.
+
+        try {
+            // Step 1: Delete mail status from store
+            this.mailStatusStore.delete(uniqueMessageId, Collections.<String, Object>emptyMap());
+            // Step 2: Delete any matching serialized mail
+            this.mailContentStore.delete(batchId, uniqueMessageId);
+        } catch (MailStoreException e) {
+            // Save the exception for reporting through the script services's getLastError() API
+            setError(e);
+        }
+    }
+
+    /**
+     * @return the configuration for the Mail Storage
+     */
+    public MailStorageConfiguration getConfiguration()
+    {
+        return this.storageConfiguration;
+    }
+
+    private Map<String, Object> normalizeFilterMap(Map<String, Object> filterMap)
+    {
+        // Force the wiki to be the current wiki to prevent any subwiki to see the list of mail statuses from other
+        // wikis
+        Map<String, Object> normalizedMap = new HashMap<>(filterMap);
+        XWikiContext xwikiContext = this.xwikiContextProvider.get();
+        if (!xwikiContext.isMainWiki()) {
+            normalizedMap.put("wiki", xwikiContext.getWikiId());
+        }
+        return normalizedMap;
+    }
+
+    private MimeMessage loadMessage(Session session, String batchId, String mailId) throws MailStoreException
+    {
+        MimeMessage message = this.mailContentStore.load(session, batchId, mailId);
+        return message;
+    }
+
+=====================================================================
+Found a 70 line (466 tokens) duplication in the following files: 
+Starting at line 452 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+Starting at line 563 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+
+        setup.rest().delete(new DocumentReference("xwiki", "XWiki", deleteVersionTestUser));
+        setup.createUser(deleteVersionTestUser, deleteVersionTestUser, "");
+
+        setup.setGlobalRights("", deleteVersionTestUser, "admin", true);
+
+        DocumentReference xwikiPreferences = new DocumentReference("xwiki", "XWiki", "XWikiPreferences");
+        setup.gotoPage(xwikiPreferences, "view", "viewer=history");
+        HistoryPane historyPane = new HistoryPane();
+        historyPane = historyPane.showMinorEdits();
+        // store the current version as it will be our basis for next steps
+        String latestVersionBeforeChanges = historyPane.getCurrentVersion();
+        int numberOfVersions = historyPane.getNumberOfVersions();
+
+        // We just create a new major version in the history
+        setup.gotoPage(xwikiPreferences, "edit", "editor=wiki");
+        WikiEditPage wikiEditPage = new WikiEditPage();
+        wikiEditPage.clickSaveAndView();
+
+        setup.gotoPage(xwikiPreferences, "view", "viewer=history");
+        historyPane = new HistoryPane();
+        // Version where we start our changes
+        String startChangesVersion = historyPane.getCurrentVersion();
+
+        String currentMajor = startChangesVersion.split("\\.")[0];
+
+        setup.setGlobalRights("", deleteVersionTestUser, "programming", true);
+        currentMajor = String.valueOf(Integer.parseInt(currentMajor) + 1);
+
+        // We don't use setRights twice as it would create another object and we want to edit the existing one.
+        setup.gotoPage(xwikiPreferences, "edit", "editor=object");
+        ObjectEditPage objectEditPage = new ObjectEditPage();
+        List<ObjectEditPane> rightObjects = objectEditPage.getObjectsOfClass("XWiki.XWikiGlobalRights", false);
+        ObjectEditPane rightObject = rightObjects.get(rightObjects.size() - 1);
+        rightObject.displayObject();
+        assertEquals(deleteVersionTestUser, rightObject.getFieldValue(rightObject.byPropertyName("users")));
+        assertEquals("programming", rightObject.getFieldValue(rightObject.byPropertyName("levels")));
+        assertEquals("1", rightObject.getFieldValue(rightObject.byPropertyName("allow")));
+
+        rightObject.setFieldValue(rightObject.byPropertyName("allow"), "0");
+        // We want a minor version.
+        objectEditPage.clickSaveAndContinue();
+
+        // We don't use the Cancel button to leave the edit mode because it takes us to the "view" mode which, depending
+        // on whether the XWiki.XWikiPreferences page has an XWiki.XWikiPreferences object or not, can be redirected to
+        // the "admin" mode (by the XWiki preferences sheet), which locks back the XWiki.XWikiPreferences page. We want
+        // to switch the user next, which doesn't remove the lock (see XWIKI-22430: Logging out does not unlock pages
+        // that were being edited), so we leave the edit mode by going to a page that doesn't add the edit lock back.
+        setup.gotoPage(xwikiPreferences.getLastSpaceReference());
+
+        setup.login(deleteVersionTestUser, deleteVersionTestUser);
+
+        // first check that the right is properly denied in the objects
+        setup.gotoPage(xwikiPreferences, "edit", "editor=object");
+        objectEditPage = new ObjectEditPage();
+        rightObjects = objectEditPage.getObjectsOfClass("XWiki.XWikiGlobalRights", false);
+        rightObject = rightObjects.get(rightObjects.size() - 1);
+        rightObject.displayObject();
+        assertEquals(deleteVersionTestUser, rightObject.getFieldValue(rightObject.byPropertyName("users")));
+        assertEquals("programming", rightObject.getFieldValue(rightObject.byPropertyName("levels")));
+        assertEquals("0", rightObject.getFieldValue(rightObject.byPropertyName("allow")));
+
+        setup.gotoPage(xwikiPreferences, "view", "viewer=history");
+        historyPane = new HistoryPane();
+        historyPane = historyPane.showMinorEdits();
+        assertEquals(numberOfVersions + 3, historyPane.getNumberOfVersions());
+        assertEquals(currentMajor + ".2", historyPane.getCurrentVersion());
+        assertTrue(historyPane.hasVersion(currentMajor + ".1"));
+
+        try {
+            historyPane = historyPane.deleteVersion(historyPane.getCurrentVersion());
+
+=====================================================================
+Found a 55 line (435 tokens) duplication in the following files: 
+Starting at line 140 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataEntryStoreTest.java
+Starting at line 94 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
+
+            .thenAnswer(invocationOnMock -> "EventType " + invocationOnMock.getArgument(0));
+    }
+
+    @Test
+    void getMissingTarget()
+    {
+        LiveDataQuery query = mock(LiveDataQuery.class);
+        LiveDataQuery.Source source = mock(LiveDataQuery.Source.class);
+        when(query.getSource()).thenReturn(source);
+        when(source.getParameters()).thenReturn(Map.of());
+        LiveDataException liveDataException = assertThrows(LiveDataException.class, () -> this.entryStore.get(query));
+        assertEquals("The target source parameter is mandatory.", liveDataException.getMessage());
+    }
+
+    @Test
+    void getBadAuthorization() throws LiveDataException
+    {
+        LiveDataQuery query = mock(LiveDataQuery.class);
+        LiveDataQuery.Source source = mock(LiveDataQuery.Source.class);
+        when(query.getSource()).thenReturn(source);
+        when(source.getParameters()).thenReturn(Map.of(
+            "target", "wiki",
+            "wiki", "foo"
+        ));
+        DocumentReference userDoc = new DocumentReference("xwiki", "XWiki", "Foo");
+        when(this.contextualAuthorizationManager.hasAccess(Right.ADMIN)).thenReturn(false);
+        when(context.getUserReference()).thenReturn(userDoc);
+        LiveDataException liveDataException = assertThrows(LiveDataException.class, () -> this.entryStore.get(query));
+        assertEquals("You don't have rights to access those information.", liveDataException.getMessage());
+
+        when(this.contextualAuthorizationManager.hasAccess(Right.ADMIN)).thenReturn(true);
+        LiveData emptyLiveData = new LiveData();
+        assertEquals(emptyLiveData, this.entryStore.get(query));
+
+        when(source.getParameters()).thenReturn(Map.of(
+            "target", "user",
+            "user", "xwiki:XWiki.Bar"
+        ));
+        when(this.contextualAuthorizationManager.hasAccess(Right.ADMIN)).thenReturn(false);
+        liveDataException = assertThrows(LiveDataException.class, () -> this.entryStore.get(query));
+        assertEquals("You don't have rights to access those information.", liveDataException.getMessage());
+
+        when(this.contextualAuthorizationManager.hasAccess(Right.ADMIN)).thenReturn(true);
+        assertEquals(emptyLiveData, this.entryStore.get(query));
+
+        when(this.contextualAuthorizationManager.hasAccess(Right.ADMIN)).thenReturn(false);
+        when(source.getParameters()).thenReturn(Map.of(
+            "target", "user",
+            "user", "xwiki:XWiki.Foo"
+        ));
+        assertEquals(emptyLiveData, this.entryStore.get(query));
+    }
+
+    @Test
+    void getEntry(MockitoComponentManager componentManager) throws Exception
+
+=====================================================================
+Found a 49 line (428 tokens) duplication in the following files: 
+Starting at line 98 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/ClassResourceImplTest.java
+Starting at line 100 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/ClassesResourceImplTest.java
+
+    @Mock
+    private XWiki xWiki;
+
+    private List<String> availableClasses = Arrays.asList("Foo.Class1", "XWiki.User", "XWiki.Protected", "Bar.Other");
+    private List<DocumentReference> documentReferences = Arrays.asList(
+        new DocumentReference("xwiki", "Foo", "Class1"),
+        new DocumentReference("xwiki", "XWiki", "User"),
+        new DocumentReference("xwiki", "XWiki", "Protected"),
+        new DocumentReference("xwiki", "Bar", "Other")
+    );
+    private List<Class> restClasses;
+
+    XWikiContext xcontext;
+
+    @BeforeComponent
+    void beforeComponent() throws Exception
+    {
+        this.xcontext = mock(XWikiContext.class);
+        when(this.xcontextProvider.get()).thenReturn(this.xcontext);
+        componentManager.registerComponent(ComponentManager.class, "context", componentManager);
+        Utils.setComponentManager(componentManager);
+    }
+
+    @BeforeEach
+    void configure() throws Exception
+    {
+        when(xcontextProvider.get()).thenReturn(xcontext);
+        when(xcontext.getWiki()).thenReturn(xWiki);
+        when(xWiki.getClassList(xcontext)).thenReturn(availableClasses);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getBaseUri()).thenReturn(new URI("/xwiki/rest"));
+        ReflectionUtils.setFieldValue(resource, "uriInfo", uriInfo);
+        when(authorization.hasAccess(eq(Right.VIEW), any())).thenReturn(true);
+
+        this.restClasses = new ArrayList<>();
+        for (int i = 0; i < availableClasses.size(); i++) {
+            when(resolver.resolve(eq(availableClasses.get(i)), any())).thenReturn(documentReferences.get(i));
+            XWikiDocument doc = mock(XWikiDocument.class);
+            BaseClass baseClass = mock(BaseClass.class);
+            Class zeclass = mock(Class.class);
+            // the cast here is mandatory, else Mockito register a mock for the call to
+            // getDocument(DocumentReference, XWikiContext)
+            when(xWiki.getDocument((EntityReference)documentReferences.get(i), xcontext)).thenReturn(doc);
+            when(doc.getXClass()).thenReturn(baseClass);
+            when(modelFactory.toRestClass(any(), eq(new com.xpn.xwiki.api.Class(baseClass, xcontext))))
+                .thenReturn(zeclass);
+            when(zeclass.getId()).thenReturn(availableClasses.get(i));
+            restClasses.add(zeclass);
+        }
+
+=====================================================================
+Found a 48 line (407 tokens) duplication in the following files: 
+Starting at line 1029 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+Starting at line 361 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManagerTest.java
+
+            .setSort(RatingQueryField.CREATED_DATE.getFieldName(), SolrQuery.ORDER.asc);
+
+        QueryResponse response1 = mock(QueryResponse.class);
+        QueryResponse response2 = mock(QueryResponse.class);
+
+        AtomicInteger queryCounter = new AtomicInteger(0);
+        when(solrClient.query(any())).then(invocationOnMock -> {
+
+            SolrQuery givenQuery = invocationOnMock.getArgument(0);
+            QueryResponse result = null;
+            if (queryCounter.get() == 0) {
+                assertEquals(expectedQuery1.getQuery(), givenQuery.getQuery());
+                assertArrayEquals(expectedQuery1.getFilterQueries(), givenQuery.getFilterQueries());
+                assertEquals(expectedQuery1.getRows(), givenQuery.getRows());
+                assertEquals(expectedQuery1.getStart(), givenQuery.getStart());
+                assertEquals(expectedQuery1.getSorts(), givenQuery.getSorts());
+                result = response1;
+            } else if (queryCounter.get() == 1) {
+                assertEquals(expectedQuery2.getQuery(), givenQuery.getQuery());
+                assertArrayEquals(expectedQuery2.getFilterQueries(), givenQuery.getFilterQueries());
+                assertEquals(expectedQuery2.getRows(), givenQuery.getRows());
+                assertEquals(expectedQuery2.getStart(), givenQuery.getStart());
+                assertEquals(expectedQuery2.getSorts(), givenQuery.getSorts());
+                result = response2;
+            } else {
+                fail("Too many requests performed.");
+            }
+            queryCounter.getAndIncrement();
+            return result;
+        });
+        when(response1.getResults()).thenReturn(this.documentList);
+        when(response2.getResults()).thenReturn(new SolrDocumentList());
+
+        doAnswer(invocationOnMock -> {
+            String modifier = invocationOnMock.getArgument(0);
+            String fieldName = invocationOnMock.getArgument(1);
+            Object fieldValue = invocationOnMock.getArgument(2);
+            // we normally only invoke it with entity reference.
+            assertEquals(EntityReference.class, invocationOnMock.getArgument(3));
+            SolrInputDocument solrInputDocument = invocationOnMock.getArgument(4);
+            solrInputDocument.setField(fieldName, Collections.singletonMap(modifier, fieldValue));
+            return null;
+        }).when(this.solrUtils).setAtomic(any(), any(), any(), any(), any());
+
+        // expected committed documents
+        SolrInputDocument solrInputDocument1 = new SolrInputDocument();
+        solrInputDocument1.setField("id", "rating1");
+        solrInputDocument1.setField(RatingQueryField.ENTITY_REFERENCE.getFieldName(),
+
+=====================================================================
+Found a 42 line (396 tokens) duplication in the following files: 
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 164 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        boolean onlyGivenType = false;
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // All formats will be accepted
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats()).thenReturn(null);
+
+        // pref4 does not contain the right event type, it will be discarded.
+        // pref5 does not contain any specific event type, so it should match all since onlyGivenType is false.
+        when(pref3.getEventTypes()).thenReturn(Collections.singleton("mentions"));
+        when(pref4.getEventTypes()).thenReturn(Collections.singleton("otherEventType"));
+        when(pref5.getEventTypes()).thenReturn(Collections.emptySet());
+        when(pref6.getEventTypes()).thenReturn(new HashSet<>(Arrays.asList("like", "mentions", "comment")));
+
+        ScopeNotificationFilterPreferencesHierarchy expected = new ScopeNotificationFilterPreferencesHierarchy(
+            Arrays.asList(
+                new ScopeNotificationFilterPreference(pref3, this.entityReferenceResolver),
+                new ScopeNotificationFilterPreference(pref5, this.entityReferenceResolver),
+
+=====================================================================
+Found a 40 line (392 tokens) duplication in the following files: 
+Starting at line 112 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 220 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // All formats will be accepted
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats()).thenReturn(null);
+
+        // pref4 does not contain the right event type, it will be discarded.
+        // pref5 does not contain any specific event type, so it should match all since onlyGivenType is false.
+        when(pref3.getEventTypes()).thenReturn(Collections.singleton("mentions"));
+        when(pref4.getEventTypes()).thenReturn(Collections.singleton("otherEventType"));
+        when(pref5.getEventTypes()).thenReturn(Collections.emptySet());
+        when(pref6.getEventTypes()).thenReturn(new HashSet<>(Arrays.asList("like", "mentions", "comment")));
+
+        ScopeNotificationFilterPreferencesHierarchy expected = new ScopeNotificationFilterPreferencesHierarchy(
+            Arrays.asList(
+                new ScopeNotificationFilterPreference(pref3, this.entityReferenceResolver),
+                new ScopeNotificationFilterPreference(pref5, this.entityReferenceResolver),
+
+=====================================================================
+Found a 39 line (392 tokens) duplication in the following files: 
+Starting at line 166 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 220 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // All formats will be accepted
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats()).thenReturn(null);
+
+        // eventType is null and onlyGivenType is false so any event type will be accepted.
+        when(pref3.getEventTypes()).thenReturn(Collections.singleton("mentions"));
+        when(pref4.getEventTypes()).thenReturn(Collections.singleton("otherEventType"));
+        when(pref5.getEventTypes()).thenReturn(Collections.emptySet());
+        when(pref6.getEventTypes()).thenReturn(new HashSet<>(Arrays.asList("like", "mentions", "comment")));
+
+        ScopeNotificationFilterPreferencesHierarchy expected = new ScopeNotificationFilterPreferencesHierarchy(
+            Arrays.asList(
+                new ScopeNotificationFilterPreference(pref3, this.entityReferenceResolver),
+                new ScopeNotificationFilterPreference(pref4, this.entityReferenceResolver),
+
+=====================================================================
+Found a 39 line (379 tokens) duplication in the following files: 
+Starting at line 218 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 271 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        boolean onlyGivenType = true;
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // All formats will be accepted
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats()).thenReturn(null);
+
+        // pref4 does not contain the right event type, it will be discarded.
+        // pref5 does not contain any specific event type, and onlyGivenType is true so it doesn't match.
+        when(pref3.getEventTypes()).thenReturn(Collections.singleton("mentions"));
+        when(pref4.getEventTypes()).thenReturn(Collections.singleton("otherEventType"));
+        when(pref5.getEventTypes()).thenReturn(Collections.emptySet());
+        when(pref6.getEventTypes()).thenReturn(new HashSet<>(Arrays.asList("like", "mentions", "comment")));
+
+        ScopeNotificationFilterPreferencesHierarchy expected = new ScopeNotificationFilterPreferencesHierarchy(
+
+=====================================================================
+Found a 37 line (375 tokens) duplication in the following files: 
+Starting at line 112 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 273 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // All formats will be accepted
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats()).thenReturn(null);
+
+        // pref4 does not contain the right event type, it will be discarded.
+        // pref5 does not contain any specific event type, so it should match all since onlyGivenType is false.
+        when(pref3.getEventTypes()).thenReturn(Collections.singleton("mentions"));
+        when(pref4.getEventTypes()).thenReturn(Collections.singleton("otherEventType"));
+        when(pref5.getEventTypes()).thenReturn(Collections.emptySet());
+        when(pref6.getEventTypes()).thenReturn(new HashSet<>(Arrays.asList("like", "mentions", "comment")));
+
+        ScopeNotificationFilterPreferencesHierarchy expected = new ScopeNotificationFilterPreferencesHierarchy(
+
+=====================================================================
+Found a 36 line (375 tokens) duplication in the following files: 
+Starting at line 166 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 273 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // All formats will be accepted
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats()).thenReturn(null);
+
+        // eventType is null and onlyGivenType is false so any event type will be accepted.
+        when(pref3.getEventTypes()).thenReturn(Collections.singleton("mentions"));
+        when(pref4.getEventTypes()).thenReturn(Collections.singleton("otherEventType"));
+        when(pref5.getEventTypes()).thenReturn(Collections.emptySet());
+        when(pref6.getEventTypes()).thenReturn(new HashSet<>(Arrays.asList("like", "mentions", "comment")));
+
+        ScopeNotificationFilterPreferencesHierarchy expected = new ScopeNotificationFilterPreferencesHierarchy(
+
+=====================================================================
+Found a 41 line (370 tokens) duplication in the following files: 
+Starting at line 283 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 512 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery(queryString, Query.HQL)).thenReturn(query);
+        when(query.bindValue("owner", owner)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter1 = new DefaultQueryParameter(null);
+        queryParameter1.literal("foo").anyChars();
+        when(query.bindValue("constraint_0", queryParameter1)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter2 = new DefaultQueryParameter(null);
+        queryParameter2.anyChars().literal("bar").anyChars();
+        when(query.bindValue("constraint_1", queryParameter2)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter3 = new DefaultQueryParameter(null);
+        queryParameter3.literal("buz");
+        when(query.bindValue("constraint_2", queryParameter3)).thenReturn(query);
+
+        when(query.bindValue("filterType", NotificationFilterType.INCLUSIVE)).thenReturn(query);
+
+        when(query.setWiki(wikiName)).thenReturn(query);
+        when(query.setOffset(offset.intValue())).thenReturn(query);
+        when(query.setLimit(limit)).thenReturn(query);
+
+        List<Object> expectedList = List.of(
+            mock(NotificationFilterPreference.class, "filterPref1"),
+            mock(NotificationFilterPreference.class, "filterPref2"),
+            mock(NotificationFilterPreference.class, "filterPref3")
+        );
+        when(query.execute()).thenReturn(expectedList);
+        assertEquals(expectedList, this.queryHelper.getFilterPreferences(ldQuery, owner, wikiReference));
+        verify(query).bindValue("owner", owner);
+        verify(query).bindValue("constraint_0", queryParameter1);
+        verify(query).bindValue("constraint_1", queryParameter2);
+        verify(query).bindValue("constraint_2", queryParameter3);
+        verify(query).bindValue("filterType", NotificationFilterType.INCLUSIVE);
+        verify(query).setWiki(wikiName);
+        verify(query).setOffset(offset.intValue());
+        verify(query).setLimit(limit);
+    }
+
+    @Test
+    void countFilterPreferencesFilterNoSort() throws QueryException, LiveDataException
+
+=====================================================================
+Found a 30 line (359 tokens) duplication in the following files: 
+Starting at line 132 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+Starting at line 95 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManagerTest.java
+
+        when(this.solrUtils.toCompleteFilterQueryString(any()))
+            .then(invocationOnMock -> invocationOnMock.getArgument(0).toString().replaceAll(":", "\\\\:"));
+        when(this.solrUtils.toCompleteFilterQueryString(any(), any()))
+            .then(invocationOnMock -> invocationOnMock.getArgument(0).toString().replaceAll(":", "\\\\:"));
+        when(this.solrUtils.getId(any()))
+            .then(invocationOnMock -> ((SolrDocument) invocationOnMock.getArgument(0)).get("id"));
+        when(this.solrUtils.get(any(), any()))
+            .then(invocationOnMock ->
+                ((SolrDocument) invocationOnMock.getArgument(1)).get(invocationOnMock.getArgument(0)));
+        doAnswer(invocationOnMock -> {
+            String fieldName = invocationOnMock.getArgument(0);
+            Object fieldValue = invocationOnMock.getArgument(1);
+            SolrInputDocument inputDocument = invocationOnMock.getArgument(2);
+            inputDocument.setField(fieldName, fieldValue);
+            return null;
+        }).when(this.solrUtils).set(any(), any(Object.class), any());
+        doAnswer(invocationOnMock -> {
+            Object fieldValue = invocationOnMock.getArgument(0);
+            SolrInputDocument inputDocument = invocationOnMock.getArgument(1);
+            inputDocument.setField("id", fieldValue);
+            return null;
+        }).when(this.solrUtils).setId(any(), any());
+        doAnswer(invocationOnMock -> {
+            String fieldName = invocationOnMock.getArgument(0);
+            Object fieldValue = invocationOnMock.getArgument(1);
+            Type type = invocationOnMock.getArgument(2);
+            SolrInputDocument inputDocument = invocationOnMock.getArgument(3);
+            inputDocument.setField(fieldName, fieldValue);
+            return null;
+        }).when(this.solrUtils).setString(any(), any(Object.class), any(), any());
+
+=====================================================================
+Found a 51 line (358 tokens) duplication in the following files: 
+Starting at line 172 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactoryTest.java
+Starting at line 178 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactoryTest.java
+
+            .thenReturn(Collections.singletonList(filterList.get(1)));
+
+        when(notificationPreferenceManager.getPreferences(eq(USER_REFERENCE), eq(true), same(NotificationFormat.EMAIL)))
+            .thenReturn(this.mailPreferenceList);
+        when(notificationPreferenceManager.getPreferences(eq(USER_REFERENCE), eq(true), same(NotificationFormat.ALERT)))
+            .thenReturn(this.alertPreferenceList);
+
+        when(notificationFilterPreferenceManager.getFilterPreferences(USER_REFERENCE))
+            .thenReturn(this.filterPreferenceList);
+
+        when(recordableEventDescriptorManager.getRecordableEventDescriptors(true))
+            .thenReturn(recordableEventDescriptors);
+
+        when(relativeEntityReferenceResolver.resolve(isNotNull(), isNotNull())).thenAnswer(new Answer<EntityReference>()
+        {
+            public EntityReference answer(InvocationOnMock invocation) throws Throwable
+            {
+                String pageName = invocation.getArgument(0, String.class);
+                EntityType type = invocation.getArgument(1, EntityType.class);
+                return new EntityReference(pageName, type);
+            }
+        });
+
+        when(entityReferenceResolver.resolve(isNotNull(), isNotNull(), isNotNull()))
+            .thenAnswer(new Answer<EntityReference>()
+            {
+                public EntityReference answer(InvocationOnMock invocation) throws Throwable
+                {
+                    String pageName = invocation.getArgument(0, String.class);
+                    EntityType type = invocation.getArgument(1, EntityType.class);
+                    EntityReference parent = invocation.getArgument(2, EntityReference.class);
+                    return new EntityReference(pageName, type, parent);
+                }
+            });
+
+        when(entityReferenceSerializer.serialize(isNotNull())).thenAnswer(new Answer<String>()
+        {
+            public String answer(InvocationOnMock invocation) throws Throwable
+            {
+                EntityReference param = invocation.getArgument(0, EntityReference.class);
+                EntityReference parent = param.getParent();
+                if (parent != null) {
+                    assertEquals(EntityType.WIKI, parent.getType());
+                    return parent.getName() + "@@" + param.getName();
+                }
+                return param.getName();
+            }
+        });
+    }
+
+    @Test
+
+=====================================================================
+Found a 42 line (358 tokens) duplication in the following files: 
+Starting at line 126 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+Starting at line 211 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+
+    void onEventWhenNonTerminalDocumentOnMainWiki() throws Exception
+    {
+        DocumentReference source = new DocumentReference("xwiki", "PageA", "WebHome");
+        DocumentReference target = new DocumentReference("xwiki", "PageB", "WebHome");
+        when(serializer.serialize(new SpaceReference("PageA", new WikiReference("xwiki")))).thenReturn("xwiki:PageA");
+        when(serializer.serialize(new SpaceReference("PageB", new WikiReference("xwiki")))).thenReturn("xwiki:PageB");
+        when(serializer.serialize(source)).thenReturn("xwiki:PageA.WebHome");
+        when(serializer.serialize(target)).thenReturn("xwiki:PageB.WebHome");
+
+        // Mock
+        when(wikiDescriptorManager.getAllIds()).thenReturn(List.of("mainWiki"));
+
+        session = mock(Session.class);
+        when(hibernateStore.getSession(eq(xwikicontext))).thenReturn(session);
+        Query query = mock(Query.class);
+        when(session.createQuery(
+            "update DefaultNotificationFilterPreference p set p.page = :newPage " + "where p.page = :oldPage"))
+                .thenReturn(query);
+        when(query.setParameter(any(String.class), any())).thenReturn(query);
+        Query query2 = mock(Query.class);
+        when(session.createQuery(
+            "update DefaultNotificationFilterPreference p set p.pageOnly = :newPage " + "where p.pageOnly = :oldPage"))
+                .thenReturn(query2);
+        when(query2.setParameter(any(String.class), any())).thenReturn(query2);
+
+        // Test
+        DocumentRenamedEvent event = new DocumentRenamedEvent(source, target);
+        this.listener.onEvent(event, null, null);
+
+        // Verify
+        verify(cachedModelBridge).clearCache();
+        verify(query).setParameter("newPage", "xwiki:PageB");
+        verify(query).setParameter("oldPage", "xwiki:PageA");
+        verify(query).executeUpdate();
+        verify(query2).setParameter("newPage", "xwiki:PageB.WebHome");
+        verify(query2).setParameter("oldPage", "xwiki:PageA.WebHome");
+        verify(query2).executeUpdate();
+        verify(namespaceContextExecutor).execute(eq(new WikiNamespace("mainWiki")), any());
+    }
+
+    @Test
+    void onEventWhenNonTerminalDocumentOnMainWikiLocalStoreOnly() throws Exception
+
+=====================================================================
+Found a 133 line (343 tokens) duplication in the following files: 
+Starting at line 107 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-default/src/main/java/org/xwiki/mail/script/DeprecatedMailSenderScriptService.java
+Starting at line 105 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/MailSenderScriptService.java
+
+        return createMessages(hint, source, Collections.<String, Object>emptyMap());
+    }
+
+    /**
+     * Construct an iterator of Mime Messages by running the Component implementation of {@link
+     * org.xwiki.mail.MimeMessageFactory} corresponding to the passed hint.
+     *
+     * @param hint the component hint of a {@link org.xwiki.mail.MimeMessageFactory} component
+     * @param source the source from which to prefill the Mime Messages (depends on the implementation)
+     * @param parameters an optional generic list of parameters. The supported parameters depend on the implementation
+     * @return the pre-filled Mime Message iterator
+     */
+    public Iterator<MimeMessage> createMessages(String hint, Object source, Map<String, Object> parameters)
+    {
+        Iterator<MimeMessage> result;
+        try {
+            MimeMessageFactory<Iterator<MimeMessage>> factory = MimeMessageFactoryProvider.get(hint,
+                new DefaultParameterizedType(null, Iterator.class, MimeMessage.class),
+                this.componentManagerProvider.get());
+            result = factory.createMessage(source, parameters);
+        } catch (Exception e) {
+            // No factory found or error in constructing the message iterator, set an error
+            // An error occurred, save it and return null
+            setError(e);
+            return null;
+        }
+
+        return result;
+    }
+
+    /**
+     * Creates a pre-filled Mime Message by running the Component implementation of {@link
+     * org.xwiki.mail.MimeMessageFactory} corresponding to the passed hint.
+     *
+     * @param hint the component hint of a {@link org.xwiki.mail.MimeMessageFactory} component
+     * @param source the source from which to prefill the Mime Message (depends on the implementation)
+     * @return the pre-filled Mime Message wrapped in a {@link ScriptMimeMessage} instance
+     */
+    public ScriptMimeMessage createMessage(String hint, Object source)
+    {
+        return createMessage(hint, source, Collections.<String, Object>emptyMap());
+    }
+
+    /**
+     * Create an empty Mail message. The user of this API needs to set the recipients, the subject, and the message
+     * content (aka Parts) before sending the mail. Note that if not specified, the "From" sender name will be taken
+     * from the Mail Sender Configuration.
+     *
+     * @return the created Body Part or null if an error happened
+     */
+    public ScriptMimeMessage createMessage()
+    {
+        return createMessage(null, null, (String) null);
+    }
+
+    /**
+     * Create a Mail message with the "To" recipient and the mail subject set. The user of this API needs to set the
+     * message content (aka Parts) before sending the mail. Note that the "From" sender name is taken from the Mail
+     * Sender Configuration.
+     *
+     * @param to the "To" email address
+     * @param subject the subject of the mail to send
+     * @return the created Body Part or null if an error happened
+     */
+    public ScriptMimeMessage createMessage(String to, String subject)
+    {
+        return createMessage(this.senderConfiguration.getFromAddress(), to, subject);
+    }
+
+    /**
+     * Create a Mail message with the "To" recipient and the mail subject set. The user of this API needs to set the
+     * message content (aka Parts) before sending the mail. Note that the "From" sender name from the Mail Sender
+     * Configuration is overridden by the passed "From" parameter.
+     *
+     * @param from the email address of the sender
+     * @param to the "To" email address
+     * @param subject the subject of the mail to send
+     * @return the created Body Part or null if an error happened
+     */
+    public ScriptMimeMessage createMessage(String from, String to, String subject)
+    {
+        ScriptMimeMessage scriptMessage = new ScriptMimeMessage(this.execution, this.componentManagerProvider.get());
+
+        try {
+            if (from != null) {
+                scriptMessage.setFrom(InternetAddress.parse(from)[0]);
+            }
+            if (to != null) {
+                scriptMessage.addRecipients(Message.RecipientType.TO, InternetAddress.parse(to));
+            }
+            scriptMessage.setSubject(subject);
+        } catch (Exception e) {
+            // An error occurred, save it and return null
+            setError(e);
+            return null;
+        }
+
+        return scriptMessage;
+    }
+
+    /**
+     * Send one mail synchronously with Memory MailListener .
+     *
+     * @param message the message that was tried to be sent
+     * @return the result and status of the send batch
+     */
+    public ScriptMailResult send(MimeMessage message)
+    {
+        return send(Arrays.asList(message));
+    }
+
+    /**
+     * Send the list of mails synchronously, using a Memory {@link }MailListener} to store the results.
+     *
+     * @param messages the list of messages to send
+     * @return the result and status of the send batch
+     */
+    public ScriptMailResult send(Iterable<? extends MimeMessage> messages)
+    {
+        return send(messages, "memory");
+    }
+
+    /**
+     * Send the mail synchronously (wait till the message is sent). Any error can be retrieved by using the
+     * returned {@link ScriptMailResult}.
+     *
+     * @param messages the list of messages to send
+     * @param hint the component hint of a {@link org.xwiki.mail.MailListener} component
+     * @return the result and status of the send batch
+     */
+    public ScriptMailResult send(Iterable<? extends MimeMessage> messages, String hint)
+    {
+        ScriptMailResult scriptMailResult = sendAsynchronously(messages, hint);
+
+=====================================================================
+Found a 39 line (341 tokens) duplication in the following files: 
+Starting at line 359 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPluginTest.java
+Starting at line 253 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPluginTest.java
+
+        when(currentDoc.getObjects(className)).thenReturn(null);
+        assertFalse(this.skinExtensionPlugin.hasPageExtensions(context));
+        verify(currentDoc).getObjects(className);
+
+        BaseObject baseObject = mock(BaseObject.class, "specificObj");
+        when(baseObject.getStringValue("use")).thenReturn("wiki");
+        Vector<BaseObject> objectList = new Vector<>();
+        objectList.add(mock(BaseObject.class));
+        objectList.add(null);
+        objectList.add(mock(BaseObject.class));
+        objectList.add(baseObject);
+        objectList.add(null);
+        objectList.add(mock(BaseObject.class));
+
+        when(currentDoc.getObjects(className)).thenReturn(objectList);
+        assertFalse(this.skinExtensionPlugin.hasPageExtensions(context));
+        verifyNoInteractions(this.authorizationManager);
+
+        when(baseObject.getStringValue("use")).thenReturn("currentPage");
+        DocumentReference documentReference = new DocumentReference("xwiki", "MySpace", "SomePage");
+        DocumentReference userReference = new DocumentReference("xwiki", "XWiki", "Foo");
+        when(currentDoc.getDocumentReference()).thenReturn(documentReference);
+        when(currentDoc.getAuthorReference()).thenReturn(userReference);
+
+        when(this.authorizationManager.hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference, documentReference))
+            .thenReturn(false);
+        assertFalse(this.skinExtensionPlugin.hasPageExtensions(context));
+        verify(this.authorizationManager)
+            .hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference, documentReference);
+
+        assertEquals(1, this.logCapture.size());
+        assertEquals("Extensions present in [xwiki:MySpace.SomePage] ignored because of lack of script right "
+            + "from the author.", this.logCapture.getMessage(0));
+
+        when(this.authorizationManager.hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference, documentReference))
+            .thenReturn(true);
+        assertTrue(this.skinExtensionPlugin.hasPageExtensions(context));
+    }
+}
+
+=====================================================================
+Found a 52 line (334 tokens) duplication in the following files: 
+Starting at line 415 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+Starting at line 202 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+
+        assertEquals("You are about to delete pages that contain used XClass.", jobQuestionPane.getQuestionTitle());
+        TreeElement treeElement = jobQuestionPane.getQuestionTree();
+        List<TreeNodeElement> topLevelNodes = treeElement.getTopLevelNodes();
+
+        // there is two main nodes:
+        //  1. to represent free pages
+        //  2. to represent classes with associated objects
+        assertEquals(2, topLevelNodes.size());
+        TreeNodeElement freePages = topLevelNodes.get(0);
+        assertEquals("Pages that do not contain any used XClass", freePages.getLabel());
+        assertFalse(freePages.isSelected());
+
+        freePages = freePages.open().waitForIt();
+        List<TreeNodeElement> children = freePages.getChildren();
+
+        // free pages should contain three nodes with alphabetical order:
+        //   1. the FreePage obviously
+        //   2. the ObjectPage since it does not contain a class
+        //   3. the WebHome page
+        assertEquals(3, children.size());
+
+        TreeNodeElement freePage = children.get(0);
+        assertEquals(freePageName, freePage.getLabel());
+        assertEquals(space + "." + freePageName, freePage.getId());
+        assertTrue(freePage.isLeaf());
+
+        TreeNodeElement objectPage = children.get(1);
+        assertEquals(objectPageName, objectPage.getLabel());
+        assertEquals(space + "." + objectPageName, objectPage.getId());
+        assertTrue(objectPage.isLeaf());
+
+        TreeNodeElement webHome = children.get(2);
+
+        // label = page title
+        assertEquals("Parent", webHome.getLabel());
+        assertEquals(space + ".WebHome", webHome.getId());
+        assertTrue(webHome.isLeaf());
+
+        TreeNodeElement classPage = topLevelNodes.get(1);
+        assertEquals(classPageName, classPage.getLabel());
+        assertEquals(space + "." + classPageName, classPage.getId());
+        assertFalse(classPage.isSelected());
+
+        classPage = classPage.open().waitForIt();
+        children = classPage.getChildren();
+        assertEquals(1, children.size());
+
+        assertEquals(objectPageName, children.get(0).getLabel());
+
+        // here it's an object
+        assertEquals("object-" + space + "." + objectPageName, children.get(0).getId());
+        assertTrue(children.get(0).isLeaf());
+
+=====================================================================
+Found a 41 line (329 tokens) duplication in the following files: 
+Starting at line 383 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 626 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        ));
+
+        String queryString = "select count(nfp.id) from DefaultNotificationFilterPreference nfp where owner = :owner "
+            + "and ((nfp.pageOnly like :constraint_0 or nfp.page like :constraint_0 or nfp.wiki like :constraint_0 or "
+            + "nfp.user like :constraint_0) or (nfp.pageOnly like :constraint_1 or nfp.page like :constraint_1 or "
+            + "nfp.wiki like :constraint_1 or nfp.user like :constraint_1) or (nfp.pageOnly = :constraint_2 or "
+            + "nfp.page = :constraint_2 or nfp.wiki = :constraint_2 or nfp.user = :constraint_2)) and "
+            + "length(nfp.allEventTypes) = 0 and nfp.enabled = true and length(nfp.pageOnly) > 0 and "
+            + "nfp.filterType = :filterType";
+
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery(queryString, Query.HQL)).thenReturn(query);
+        when(query.bindValue("owner", owner)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter1 = new DefaultQueryParameter(null);
+        queryParameter1.literal("foo").anyChars();
+        when(query.bindValue("constraint_0", queryParameter1)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter2 = new DefaultQueryParameter(null);
+        queryParameter2.anyChars().literal("bar").anyChars();
+        when(query.bindValue("constraint_1", queryParameter2)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter3 = new DefaultQueryParameter(null);
+        queryParameter3.literal("buz");
+        when(query.bindValue("constraint_2", queryParameter3)).thenReturn(query);
+
+        when(query.bindValue("filterType", NotificationFilterType.INCLUSIVE)).thenReturn(query);
+
+        when(query.setWiki(wikiName)).thenReturn(query);
+
+        when(query.execute()).thenReturn(List.of(3L));
+        assertEquals(3L, this.queryHelper.countTotalFilters(ldQuery, owner, wikiReference));
+        verify(query).bindValue("owner", owner);
+        verify(query).bindValue("constraint_0", queryParameter1);
+        verify(query).bindValue("constraint_1", queryParameter2);
+        verify(query).bindValue("constraint_2", queryParameter3);
+        verify(query).bindValue("filterType", NotificationFilterType.INCLUSIVE);
+        verify(query).setWiki(wikiName);
+        verify(query, never()).setOffset(anyInt());
+        verify(query, never()).setLimit(anyInt());
+    }
+
+=====================================================================
+Found a 31 line (325 tokens) duplication in the following files: 
+Starting at line 150 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
+Starting at line 245 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
+
+    public void validateEquals()
+    {
+        EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
+
+        EntityReference reference2 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
+
+        EntityReference reference3 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI)));
+
+        EntityReference reference4 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference("space2", EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
+
+        EntityReference reference5 = new EntityReference("page2", EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
+
+        EntityReference reference6 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT);
+
+        Map<String, Serializable> map = getParamMap(3);
+        EntityReference reference7 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)), map);
+
+        EntityReference reference8 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)), map);
+
+        EntityReference reference9 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI), map));
+
+        EntityReference reference10 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI, null, map)));
+
+=====================================================================
+Found a 43 line (319 tokens) duplication in the following files: 
+Starting at line 112 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+Starting at line 256 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+
+        assertEquals("validationScript", xclass.getValidationScript());
+
+        NumberClass numberFiled = (NumberClass) xclass.getField("prop1");
+        assertEquals("prop1", numberFiled.getName());
+        assertEquals(false, numberFiled.isDisabled());
+        assertEquals(1, numberFiled.getNumber());
+        assertEquals("long", numberFiled.getNumberType());
+        assertEquals("Prop1", numberFiled.getPrettyName());
+        assertEquals(30, numberFiled.getSize());
+        assertEquals(false, numberFiled.isUnmodifiable());
+
+        // Objects
+
+        Map<DocumentReference, List<BaseObject>> objects = document.getXObjects();
+        assertEquals(2, objects.size());
+
+        // Object 1
+
+        List<BaseObject> documentObjects = objects.get(new DocumentReference("wiki", "space", "page"));
+        assertEquals(1, documentObjects.size());
+        BaseObject documentObject = documentObjects.get(0);
+        assertEquals(0, documentObject.getNumber());
+        assertEquals(new DocumentReference("wiki", "space", "page"), documentObject.getXClassReference());
+        assertEquals("e2167721-2a64-430c-9520-bac1c0ee68cb", documentObject.getGuid());
+
+        assertEquals(1, documentObject.getFieldList().size());
+        assertEquals(1, documentObject.getIntValue("prop1"));
+
+        // Object 2
+
+        List<BaseObject> otherObjects = objects.get(new DocumentReference("wiki", "otherspace", "otherclass"));
+        assertEquals(1, otherObjects.size());
+        BaseObject otherObject = otherObjects.get(0);
+        assertEquals(0, otherObject.getNumber());
+        assertEquals(new DocumentReference("wiki", "otherspace", "otherclass"), otherObject.getXClassReference());
+        assertEquals("8eaeac52-e2f2-47b2-87e1-bc6909597b39", otherObject.getGuid());
+
+        assertEquals(1, otherObject.getFieldList().size());
+        assertEquals(2, otherObject.getIntValue("prop2"));
+    }
+
+    @Test
+    void importDocument1WithPreserveVersion() throws FilterException, XWikiException, ParseException
+
+=====================================================================
+Found a 38 line (316 tokens) duplication in the following files: 
+Starting at line 849 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+Starting at line 1023 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+
+            .thenReturn(Arrays.asList(rating1, rating2, rating3, rating4).stream());
+
+        SolrQuery expectedQuery2 = new SolrQuery()
+            .addFilterQuery(filterQuery)
+            .setRows(100)
+            .setStart(100)
+            .setSort(RatingQueryField.CREATED_DATE.getFieldName(), SolrQuery.ORDER.asc);
+
+        QueryResponse response1 = mock(QueryResponse.class);
+        QueryResponse response2 = mock(QueryResponse.class);
+
+        AtomicInteger queryCounter = new AtomicInteger(0);
+        when(solrClient.query(any())).then(invocationOnMock -> {
+
+            SolrQuery givenQuery = invocationOnMock.getArgument(0);
+            QueryResponse result = null;
+            if (queryCounter.get() == 0) {
+                assertEquals(expectedQuery1.getQuery(), givenQuery.getQuery());
+                assertArrayEquals(expectedQuery1.getFilterQueries(), givenQuery.getFilterQueries());
+                assertEquals(expectedQuery1.getRows(), givenQuery.getRows());
+                assertEquals(expectedQuery1.getStart(), givenQuery.getStart());
+                assertEquals(expectedQuery1.getSorts(), givenQuery.getSorts());
+                result = response1;
+            } else if (queryCounter.get() == 1) {
+                assertEquals(expectedQuery2.getQuery(), givenQuery.getQuery());
+                assertArrayEquals(expectedQuery2.getFilterQueries(), givenQuery.getFilterQueries());
+                assertEquals(expectedQuery2.getRows(), givenQuery.getRows());
+                assertEquals(expectedQuery2.getStart(), givenQuery.getStart());
+                assertEquals(expectedQuery2.getSorts(), givenQuery.getSorts());
+                result = response2;
+            } else {
+                fail("Too many requests performed.");
+            }
+            queryCounter.getAndIncrement();
+            return result;
+        });
+        when(response1.getResults()).thenReturn(this.documentList);
+        when(response2.getResults()).thenReturn(new SolrDocumentList());
+
+=====================================================================
+Found a 50 line (313 tokens) duplication in the following files: 
+Starting at line 311 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactoryTest.java
+Starting at line 312 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactoryTest.java
+
+        notificationParameters.filters = new HashSet<>(Arrays.asList(filterList.get(1), filterList.get(2)));
+
+        List<NotificationFilterPreference> notificationFilterPreferences = new ArrayList<>();
+        DefaultNotificationFilterPreference filterPref = getFilterPreference("PAGE", 0);
+        filterPref.setPageOnly("mywiki@@a");
+        notificationFilterPreferences
+            .add(new ScopeNotificationFilterPreference(filterPref, this.entityReferenceResolver));
+
+        filterPref = getFilterPreference("PAGE", 1);
+        filterPref.setPageOnly("mywiki@@b");
+        notificationFilterPreferences
+            .add(new ScopeNotificationFilterPreference(filterPref, this.entityReferenceResolver));
+
+        filterPref = getFilterPreference("PAGE", 2);
+        filterPref.setPageOnly("mywiki@@c");
+        notificationFilterPreferences
+            .add(new ScopeNotificationFilterPreference(filterPref, this.entityReferenceResolver));
+
+        filterPref = getFilterPreference("SPACE", 0);
+        filterPref.setPage("mywiki@@space1");
+        notificationFilterPreferences
+            .add(new ScopeNotificationFilterPreference(filterPref, this.entityReferenceResolver));
+
+        filterPref = getFilterPreference("SPACE", 1);
+        filterPref.setPage("mywiki@@space2");
+        notificationFilterPreferences
+            .add(new ScopeNotificationFilterPreference(filterPref, this.entityReferenceResolver));
+
+        filterPref = getFilterPreference("WIKI", 0);
+        filterPref.setWiki("wiki1");
+        notificationFilterPreferences
+            .add(new ScopeNotificationFilterPreference(filterPref, this.entityReferenceResolver));
+
+        filterPref = getFilterPreference("WIKI", 1);
+        filterPref.setWiki("wiki2");
+        notificationFilterPreferences
+            .add(new ScopeNotificationFilterPreference(filterPref, this.entityReferenceResolver));
+
+        notificationFilterPreferences.add(new TagNotificationFilterPreference("d", "mywiki"));
+        notificationFilterPreferences.add(new TagNotificationFilterPreference("e", "mywiki"));
+        notificationFilterPreferences.add(new TagNotificationFilterPreference("f", "mywiki"));
+
+        notificationParameters.filterPreferences = notificationFilterPreferences;
+        assertEquals(notificationParameters, this.parametersFactory.createNotificationParameters(parametersMap));
+        verify(this.usersParameterHandler).handleUsersParameter("foobar,barbar", notificationParameters);
+
+        parametersMap.remove(ParametersKey.CURRENT_WIKI);
+        when(wikiDescriptorManager.getCurrentWikiId()).thenReturn("mywiki");
+        assertEquals(notificationParameters, this.parametersFactory.createNotificationParameters(parametersMap));
+        verify(wikiDescriptorManager, times(3)).getCurrentWikiId();
+
+=====================================================================
+Found a 38 line (307 tokens) duplication in the following files: 
+Starting at line 299 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentArchiveTest.java
+Starting at line 350 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentArchiveTest.java
+
+        XWikiDocument doc = new XWikiDocument(new DocumentReference("Test", "Test", "Test"));
+        XWikiDocumentArchive archive = new XWikiDocumentArchive(doc.getId());
+        doc.setDocumentArchive(archive);
+        String author = "XWiki.some author";
+
+        // We have a full version every 5 nodes, so we're injecting 15 versions
+        addRevisionToHistory(archive, doc, "content 1.1", author, "initial 1.1");
+
+        doc.setContent("content 2.1\nqwe @ ");
+        archive.updateArchive(doc, author, new Date(), "2.1", new Version(2,1), context);
+
+        doc.setContent("content 2.2\nqweq@ ");
+        archive.updateArchive(doc, author, new Date(), "2.2", new Version(2,2), context);
+
+        doc.setContent("content 2.3\nqweqe @@");
+        archive.updateArchive(doc, author, new Date(), "2.3", new Version(2,3), context);
+
+        doc.setContent("content 2.4\nqweqe @@");
+        archive.updateArchive(doc, author, new Date(), "2.4", new Version(2,4), context);
+
+        // 5 nodes so far,
+        // let's add 5
+
+        for (int i = 1; i <= 5; i++) {
+            String version = String.format("3.%s", i);
+            doc.setContent(version + "\nqweqe @@");
+            archive.updateArchive(doc, author, new Date(), version, new Version(version), context);
+        }
+
+        // let's add 7
+        for (int i = 1; i <= 7; i++) {
+            String version = String.format("4.%s", i);
+            doc.setContent(version + "\nqweqe @@");
+            archive.updateArchive(doc, author, new Date(), version, new Version(version), context);
+        }
+        assertEquals(new Version(4,7), archive.getLatestVersion());
+
+        assertEquals(new Version("2.3"), archive.getNextFullVersion(new Version("2.3")));
+
+=====================================================================
+Found a 45 line (300 tokens) duplication in the following files: 
+Starting at line 304 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+Starting at line 369 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+Starting at line 556 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+
+    public void testPUTProperty() throws Exception
+    {
+        final String TAG_VALUE = UUID.randomUUID().toString();
+
+        /* Make sure that an Object with the TagClass exists. */
+        createObjectIfDoesNotExists("XWiki.TagClass", this.spaces, this.pageName);
+
+        GetMethod getMethod =
+            executeGet(buildURI(PageResource.class, getWiki(), this.spaces, this.pageName).toString());
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Page page = (Page) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+        Link link = getFirstLinkByRelation(page, Relations.OBJECTS);
+        Assert.assertNotNull(link);
+
+        getMethod = executeGet(link.getHref());
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Objects objects = (Objects) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+
+        Assert.assertFalse(objects.getObjectSummaries().isEmpty());
+
+        Object currentObject = null;
+
+        for (ObjectSummary objectSummary : objects.getObjectSummaries()) {
+            if (objectSummary.getClassName().equals("XWiki.TagClass")) {
+                link = getFirstLinkByRelation(objectSummary, Relations.OBJECT);
+                Assert.assertNotNull(link);
+                getMethod = executeGet(link.getHref());
+                Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+                currentObject = (Object) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+                break;
+            }
+        }
+
+        Assert.assertNotNull(currentObject);
+
+        Property tagsProperty = getProperty(currentObject, "tags");
+
+        Assert.assertNotNull(tagsProperty);
+
+        Link tagsPropertyLink = getFirstLinkByRelation(tagsProperty, Relations.SELF);
+
+        Assert.assertNotNull(tagsPropertyLink);
+
+=====================================================================
+Found a 57 line (299 tokens) duplication in the following files: 
+Starting at line 50 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/test/java/org/xwiki/notifications/sources/internal/AbstractQueryGeneratorTest.java
+Starting at line 50 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/AbstractQueryGeneratorTest.java
+
+@ComponentTest
+public abstract class AbstractQueryGeneratorTest
+{
+    protected static final DocumentReference USER_REFERENCE = new DocumentReference("xwiki", "XWiki", "UserA");
+    protected static final String SERIALIZED_USER_REFERENCE = "xwiki:XWiki.UserA";
+
+    @MockComponent
+    protected WikiDescriptorManager wikiDescriptorManager;
+
+    @MockComponent
+    protected NotificationFilterManager notificationFilterManager;
+
+    @MockComponent
+    protected RecordableEventDescriptorHelper recordableEventDescriptorHelper;
+
+    @MockComponent
+    protected UserPropertiesResolver userPropertiesResolver;
+
+    @MockComponent
+    @Named("document")
+    protected UserReferenceResolver<DocumentReference> userReferenceResolver;
+
+    protected Date startDate;
+
+    protected Date pref1StartDate;
+
+    protected NotificationFilterPreference fakeFilterPreference;
+
+    protected NotificationPreference pref1;
+
+    @BeforeEach
+    public void beforeEach() throws Exception
+    {
+        this.startDate = new Date(10);
+
+        this.pref1StartDate = new Date(100000000);
+
+        this.pref1 = mock(NotificationPreference.class);
+        when(this.pref1.getProperties())
+            .thenReturn(Collections.singletonMap(NotificationPreferenceProperty.EVENT_TYPE, "create"));
+        when(this.pref1.getFormat()).thenReturn(NotificationFormat.ALERT);
+        when(this.pref1.getStartDate()).thenReturn(pref1StartDate);
+        when(this.pref1.isNotificationEnabled()).thenReturn(true);
+
+        this.fakeFilterPreference = mock(NotificationFilterPreference.class);
+
+        when(this.wikiDescriptorManager.getMainWikiId()).thenReturn("xwiki");
+
+        when(this.recordableEventDescriptorHelper.hasDescriptor(anyString(), any(DocumentReference.class)))
+            .thenReturn(true);
+
+        UserProperties userProperties = mock(UserProperties.class);
+        when(userProperties.displayHiddenDocuments()).thenReturn(false);
+        when(this.userPropertiesResolver.resolve(any(UserReference.class))).thenReturn(userProperties);
+        when(this.userReferenceResolver.resolve(USER_REFERENCE)).thenReturn(mock(UserReference.class));
+    }
+}
+
+=====================================================================
+Found a 32 line (294 tokens) duplication in the following files: 
+Starting at line 56 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 109 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        String requestedEventType = "mentions";
+        boolean onlyGivenType = false;
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // pref3 has not the right matching format, it is discarded. Others at least contains it.
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+
+=====================================================================
+Found a 40 line (293 tokens) duplication in the following files: 
+Starting at line 251 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-filters/xwiki-platform-legacy-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/LegacyDefaultNotificationFilterManagerTest.java
+Starting at line 242 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterManagerTest.java
+
+        when(this.configuration.isEventPrefilteringEnabled()).thenReturn(true);
+        Collection<NotificationFilter> allFilters = this.filterManager.getAllFilters(testUser, true,
+            NotificationFilter.FilteringPhase.PRE_FILTERING);
+        assertEquals(3, allFilters.size());
+        assertEquals(new HashSet<>(Arrays.asList(filter1, filter5, filter7)), allFilters);
+
+        // prefiltering still enabled: we request postfiltering filters that are enabled:
+        // we should not return filter2/4/6 since they are not enabled,
+        // nor filter1 because it's only for pre-filtering, nor filter5 because it's for both pre and post filtering
+        allFilters = this.filterManager.getAllFilters(testUser, true, NotificationFilter.FilteringPhase.POST_FILTERING);
+        assertEquals(1, allFilters.size());
+        assertEquals(Collections.singleton(filter3), allFilters);
+
+        // prefiltering still enabled: we request all filters that are enabled:
+        // we should not return filter2/4/6 since they are not enabled.
+        allFilters = this.filterManager.getAllFilters(testUser, true, null);
+        assertEquals(4, allFilters.size());
+        assertEquals(new HashSet<>(Arrays.asList(filter1, filter3, filter5, filter7)), allFilters);
+
+        // prefiltering still enabled: we request prefiltering filters whatever if they are enabled or not
+        // we should not return filter3 and 4 because they are only for post-filtering
+        allFilters = this.filterManager.getAllFilters(testUser, false,
+            NotificationFilter.FilteringPhase.PRE_FILTERING);
+        assertEquals(5, allFilters.size());
+        assertEquals(new HashSet<>(Arrays.asList(filter1, filter2, filter5, filter6, filter7)), allFilters);
+
+        // prefiltering still enabled: we request postfiltering filters whatever if they are enabled or not
+        // we should not return filter1/2 because they are only for pre-filtering,
+        // nor filter5/6/7 because they are for both pre and post filtering
+        allFilters = this.filterManager.getAllFilters(testUser, false,
+            NotificationFilter.FilteringPhase.POST_FILTERING);
+        assertEquals(2, allFilters.size());
+        assertEquals(new HashSet<>(Arrays.asList(filter3, filter4)), allFilters);
+
+        // prefiltering still enabled: we request all filters  whatever if they are enabled or not:
+        // we return all filters
+        allFilters = this.filterManager.getAllFilters(testUser, false, null);
+        assertEquals(7, allFilters.size());
+        assertEquals(new HashSet<>(Arrays.asList(filter1, filter2, filter3, filter4, filter5, filter6, filter7)),
+            allFilters);
+
+=====================================================================
+Found a 31 line (290 tokens) duplication in the following files: 
+Starting at line 57 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 164 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        boolean onlyGivenType = false;
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // pref3 has not the right matching format, it is discarded. Others at least contains it.
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+
+=====================================================================
+Found a 33 line (287 tokens) duplication in the following files: 
+Starting at line 242 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactoryTest.java
+Starting at line 251 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactoryTest.java
+
+            Arrays.asList(new InternalNotificationPreference(this.recordableEventDescriptors.get(0)),
+                new InternalNotificationPreference(this.recordableEventDescriptors.get(1)));
+        assertEquals(notificationParameters,
+            this.parametersFactory.createNotificationParameters(Collections.emptyMap()));
+        verify(wikiDescriptorManager).getCurrentWikiId();
+
+        Map<ParametersKey, String> parametersMap = new HashMap<>();
+        parametersMap.put(ParametersKey.FORMAT, "EMAIL");
+        parametersMap.put(ParametersKey.USER_ID, USER_SERIALIZED_REFERENCE);
+        parametersMap.put(ParametersKey.USE_USER_PREFERENCES, "true");
+        parametersMap.put(ParametersKey.UNTIL_DATE, "4242");
+        parametersMap.put(ParametersKey.UNTIL_DATE_INCLUDED, "true");
+        parametersMap.put(ParametersKey.MAX_COUNT, "1258");
+        parametersMap.put(ParametersKey.ONLY_UNREAD, "true");
+        parametersMap.put(ParametersKey.BLACKLIST, "foo,bar,baz");
+        parametersMap.put(ParametersKey.PAGES, "a,b,c");
+        parametersMap.put(ParametersKey.TAGS, "d,e,f");
+        parametersMap.put(ParametersKey.CURRENT_WIKI, "mywiki");
+        parametersMap.put(ParametersKey.DISPLAY_READ_EVENTS, "true");
+        parametersMap.put(ParametersKey.DISPLAY_SYSTEM_EVENTS, "false");
+        parametersMap.put(ParametersKey.DISPLAY_OWN_EVENTS, "true");
+        parametersMap.put(ParametersKey.DISPLAY_MINOR_EVENTS, "false");
+        parametersMap.put(ParametersKey.USERS, "foobar,barbar");
+        parametersMap.put(ParametersKey.WIKIS, "wiki1,wiki2");
+        parametersMap.put(ParametersKey.SPACES, "space1,space2");
+
+        notificationParameters = new NotificationParameters();
+        notificationParameters.format = NotificationFormat.EMAIL;
+        notificationParameters.endDate = new Date(4242);
+        notificationParameters.onlyUnread = true;
+        notificationParameters.user = USER_REFERENCE;
+        notificationParameters.expectedCount = 1258;
+        notificationParameters.blackList = Arrays.asList("foo", "bar", "baz");
+
+=====================================================================
+Found a 29 line (286 tokens) duplication in the following files: 
+Starting at line 59 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 220 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+Starting at line 273 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesGetterTest.java
+
+        NotificationFilterPreference pref1 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref2 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref3 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref4 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref5 = mock(NotificationFilterPreference.class);
+        NotificationFilterPreference pref6 = mock(NotificationFilterPreference.class);
+
+        // pref1 is not enabled, it will be discarded right away. Others are enabled.
+        when(pref1.isEnabled()).thenReturn(false);
+        when(pref2.isEnabled()).thenReturn(true);
+        when(pref3.isEnabled()).thenReturn(true);
+        when(pref4.isEnabled()).thenReturn(true);
+        when(pref5.isEnabled()).thenReturn(true);
+        when(pref6.isEnabled()).thenReturn(true);
+
+        // pref2 has not the right filter name, it is discarded. Others have the right name.
+        when(pref2.getFilterName()).thenReturn("Something");
+        when(pref3.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref4.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref5.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+        when(pref6.getFilterName()).thenReturn(ScopeNotificationFilter.FILTER_NAME);
+
+        // pref3 has not the right matching format, it is discarded. Others at least contains it.
+        when(pref3.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.EMAIL));
+        when(pref4.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+        when(pref5.getNotificationFormats()).thenReturn(Collections.singleton(NotificationFormat.ALERT));
+        when(pref6.getNotificationFormats())
+            .thenReturn(new HashSet<>(Arrays.asList(NotificationFormat.ALERT, NotificationFormat.EMAIL)));
+
+=====================================================================
+Found a 32 line (285 tokens) duplication in the following files: 
+Starting at line 855 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+Starting at line 361 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManagerTest.java
+
+            .setSort(RatingQueryField.CREATED_DATE.getFieldName(), SolrQuery.ORDER.asc);
+
+        QueryResponse response1 = mock(QueryResponse.class);
+        QueryResponse response2 = mock(QueryResponse.class);
+
+        AtomicInteger queryCounter = new AtomicInteger(0);
+        when(solrClient.query(any())).then(invocationOnMock -> {
+
+            SolrQuery givenQuery = invocationOnMock.getArgument(0);
+            QueryResponse result = null;
+            if (queryCounter.get() == 0) {
+                assertEquals(expectedQuery1.getQuery(), givenQuery.getQuery());
+                assertArrayEquals(expectedQuery1.getFilterQueries(), givenQuery.getFilterQueries());
+                assertEquals(expectedQuery1.getRows(), givenQuery.getRows());
+                assertEquals(expectedQuery1.getStart(), givenQuery.getStart());
+                assertEquals(expectedQuery1.getSorts(), givenQuery.getSorts());
+                result = response1;
+            } else if (queryCounter.get() == 1) {
+                assertEquals(expectedQuery2.getQuery(), givenQuery.getQuery());
+                assertArrayEquals(expectedQuery2.getFilterQueries(), givenQuery.getFilterQueries());
+                assertEquals(expectedQuery2.getRows(), givenQuery.getRows());
+                assertEquals(expectedQuery2.getStart(), givenQuery.getStart());
+                assertEquals(expectedQuery2.getSorts(), givenQuery.getSorts());
+                result = response2;
+            } else {
+                fail("Too many requests performed.");
+            }
+            queryCounter.getAndIncrement();
+            return result;
+        });
+        when(response1.getResults()).thenReturn(this.documentList);
+        when(response2.getResults()).thenReturn(new SolrDocumentList());
+
+=====================================================================
+Found a 47 line (269 tokens) duplication in the following files: 
+Starting at line 106 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-test/xwiki-platform-security-authentication-test-docker/src/test/it/org/xwiki/security/authentication/test/ui/ForgotUsernameIT.java
+Starting at line 170 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-test/xwiki-platform-security-authentication-test-docker/src/test/it/org/xwiki/security/authentication/test/ui/ResetPasswordIT.java
+
+        setup.deleteLatestVersion("Mail", "MailConfig");
+    }
+
+    private Map<String, String> getMessageContent(MimeMessage message) throws Exception
+    {
+        Map<String, String> messageMap = new HashMap<>();
+
+        Address[] addresses = message.getAllRecipients();
+        assertTrue(addresses.length == 1);
+        messageMap.put("recipient", addresses[0].toString());
+
+        messageMap.put("subjectLine", message.getSubject());
+
+        Multipart mp = (Multipart) message.getContent();
+
+        BodyPart plain = getPart(mp, "text/plain");
+        if (plain != null) {
+            messageMap.put("textPart", IOUtils.toString(plain.getInputStream(), "UTF-8"));
+        }
+        BodyPart html = getPart(mp, "text/html");
+        if (html != null) {
+            messageMap.put("htmlPart", IOUtils.toString(html.getInputStream(), "UTF-8"));
+        }
+
+        return messageMap;
+    }
+
+    private BodyPart getPart(Multipart messageContent, String mimeType) throws Exception
+    {
+        for (int i = 0; i < messageContent.getCount(); i++) {
+            BodyPart part = messageContent.getBodyPart(i);
+
+            if (part.isMimeType(mimeType)) {
+                return part;
+            }
+
+            if (part.isMimeType("multipart/related") || part.isMimeType("multipart/alternative")
+                || part.isMimeType("multipart/mixed"))
+            {
+                BodyPart out = getPart((Multipart) part.getContent(), mimeType);
+                if (out != null) {
+                    return out;
+                }
+            }
+        }
+        return null;
+    }
+
+=====================================================================
+Found a 39 line (263 tokens) duplication in the following files: 
+Starting at line 128 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/NotificationMailDefaultHtmlTest.java
+Starting at line 338 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/NotificationMailDefaultHtmlTest.java
+
+        testDocument.setOriginalDocument(clone);
+
+        Event testEvent = new DefaultEvent();
+        testEvent.setApplication("test&app");
+        testEvent.setType("test&type");
+        // Mock date formatting to avoid issues with timezones.
+        Date testDate = new Date(12);
+        when(this.dateScriptService.displayTimeAgo(testDate)).thenReturn("A few minutes ago");
+        testEvent.setDate(testDate);
+        testEvent.setUser(USER_REFERENCE);
+        // Mock the user's name.
+        when(this.oldcore.getSpyXWiki().getPlainUserName(USER_REFERENCE, this.context)).thenReturn("First & Name");
+        testEvent.setDocument(TEST_DOCUMENT_REFERENCE);
+        testEvent.setDocumentVersion(testDocument.getVersion());
+
+        String eventType = "test&type";
+        RecordableEventDescriptor recordableEventDescriptor = mock(RecordableEventDescriptor.class);
+        when(this.eventStreamScriptService.getDescriptorForEventType(eventType, true))
+            .thenReturn(recordableEventDescriptor);
+        when(recordableEventDescriptor.getApplicationName()).thenReturn("eventType.translationKey");
+        when(this.localizationScriptService.render("eventType.translationKey")).thenReturn("Event Test&Type");
+
+        when(this.localizationScriptService.render(eq(List.of(
+            "test&type.description.by.1user",
+            "notifications.events.test&type.description.by.1user",
+            "test&type.description",
+            "notifications.events.test&type.description"
+        )), any(Collection.class))).then(invocationOnMock -> {
+            List<String> parameters = invocationOnMock.getArgument(1);
+            assertEquals(1, parameters.size());
+
+            return "User information: "+ parameters.get(0);
+        });
+        when(this.localizationScriptService.render("web.history.changes.summary.documentProperties"))
+            .thenReturn("Document properties");
+        when(this.localizationScriptService.render("web.history.changes.document.content"))
+            .thenReturn("Content");
+
+        when(this.iconManagerScriptService.renderHTML("file-text")).thenReturn("Icon file text");
+
+=====================================================================
+Found a 29 line (247 tokens) duplication in the following files: 
+Starting at line 258 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/XObjectAverageRatingManagerTest.java
+Starting at line 343 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/XObjectAverageRatingManagerTest.java
+
+    void saveExistingRating() throws Exception
+    {
+        DocumentReference reference = new DocumentReference("xwiki","XWiki", "Foo");
+        XWikiDocument xWikiDocument = mock(XWikiDocument.class);
+        when(xWikiDocument.clone()).thenReturn(xWikiDocument);
+        when(xWikiDocument.getDocumentReference()).thenReturn(reference);
+        when(this.documentAccessBridge.getDocumentInstance(new EntityReference(reference))).thenReturn(xWikiDocument);
+        when(this.entityReferenceConverter.convert(String.class, reference)).thenReturn("document:xwiki:XWiki.Foo");
+
+        BaseObject matchingAverageRating = mock(BaseObject.class);
+        when(matchingAverageRating.getOwnerDocument()).thenReturn(xWikiDocument);
+        BaseObject anotherAverageRating = mock(BaseObject.class);
+
+        String expectedManagerID = "managerIdentifier";
+        when(this.ratingsManager.getIdentifier()).thenReturn(expectedManagerID);
+
+        when(xWikiDocument.getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
+            .thenReturn(asList(matchingAverageRating, anotherAverageRating));
+        // Wrong identifier
+        when(anotherAverageRating.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
+            .thenReturn("something");
+        when(matchingAverageRating.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
+            .thenReturn(expectedManagerID);
+        // Wrong reference
+        when(matchingAverageRating.getStringValue(AverageRatingQueryField.ENTITY_REFERENCE.getFieldName()))
+            .thenReturn("document:xwiki:XWiki.Foo");
+        XWikiContext context = mock(XWikiContext.class);
+
+        when(this.contextProvider.get()).thenReturn(context);
+
+=====================================================================
+Found a 21 line (245 tokens) duplication in the following files: 
+Starting at line 163 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+Starting at line 207 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+
+        this.baseClass = this.document.getxWikiClass();
+        this.baseClass.addTextField("string", "String", 30);
+        this.baseClass.addTextAreaField("area", "Area", 10, 10);
+        this.baseClass.addTextAreaField("puretextarea", "Pure text area", 10, 10);
+        // set the text areas an non interpreted content
+        ((TextAreaClass) this.baseClass.getField("puretextarea")).setContentType("puretext");
+        this.baseClass.addPasswordField("passwd", "Password", 30);
+        this.baseClass.addBooleanField("boolean", "Boolean", "yesno");
+        this.baseClass.addNumberField("int", "Int", 10, "integer");
+        this.baseClass.addStaticListField("stringlist", "StringList", "value1, value2");
+
+        when(this.xWiki.getClass(any(), any())).thenReturn(this.baseClass);
+        when(this.xWiki.getXClass(any(), any())).thenReturn(this.baseClass);
+
+        this.baseObject = this.document.newObject(CLASSNAME, this.oldcore.getXWikiContext());
+        this.baseObject.setStringValue("string", "string");
+        this.baseObject.setLargeStringValue("area", "area");
+        this.baseObject.setStringValue("passwd", "passwd");
+        this.baseObject.setIntValue("boolean", 1);
+        this.baseObject.setIntValue("int", 42);
+        this.baseObject.setStringListValue("stringlist", Arrays.asList("VALUE1", "VALUE2"));
+
+=====================================================================
+Found a 30 line (243 tokens) duplication in the following files: 
+Starting at line 633 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandlerTest.java
+Starting at line 766 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandlerTest.java
+
+            this.oldcore.getSpyXWiki().getDocument(new DocumentReference("wiki", "space", "page"), getXWikiContext());
+
+        assertFalse("Document wiki:space.page has not been saved in the database", modifiedpage.isNew());
+
+        assertEquals("Wrong content", "content 2", modifiedpage.getContent());
+        assertEquals("Wrong author", this.contextUser, modifiedpage.getAuthorReference());
+        assertEquals("Wrong versions", "2.1", modifiedpage.getVersion());
+        assertEquals("Wrong version", Locale.ROOT, modifiedpage.getLocale());
+
+        assertEquals("Wrong customclass", "customclass2", modifiedpage.getCustomClass());
+        assertEquals("Wrong defaultTemplate", "defaultTemplate2", modifiedpage.getDefaultTemplate());
+        assertEquals("Wrong hidden", true, modifiedpage.isHidden());
+        assertEquals("Wrong ValidationScript", "validationScript2", modifiedpage.getValidationScript());
+
+        BaseClass baseClass = modifiedpage.getXClass();
+        assertNotNull(baseClass.getField("property"));
+        assertEquals("property", baseClass.getField("property").getName());
+        assertSame(NumberClass.class, baseClass.getField("property").getClass());
+
+        XWikiAttachment attachment = modifiedpage.getAttachment("attachment.txt");
+        assertNotNull(attachment);
+        assertEquals("attachment.txt", attachment.getFilename());
+        assertEquals(18, attachment.getContentLongSize(getXWikiContext()));
+        assertEquals("attachment content",
+            IOUtils.toString(attachment.getContentInputStream(getXWikiContext()), StandardCharsets.UTF_8));
+
+        // space2.page2
+
+        XWikiDocument newPage =
+            this.oldcore.getSpyXWiki().getDocument(new DocumentReference("wiki", "space2", "page2"), getXWikiContext());
+
+=====================================================================
+Found a 23 line (243 tokens) duplication in the following files: 
+Starting at line 300 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+Starting at line 358 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+
+        when(this.xdomService.parse(newAwmContent, XWIKI_2_1))
+            .thenReturn(Optional.of(newXDOM));
+
+        List<MacroBlock> oldMentions = List.of(new MacroBlock("mention", new HashMap<>(), false));
+        when(this.xdomService.listMentionMacros(oldXDOM)).thenReturn(oldMentions);
+        List<MacroBlock> newMentions = List.of(
+            buildMentionMacro(USER_U1, "anchor1", FIRST_NAME),
+            buildMentionMacro(USER_U1, "anchor2", FIRST_NAME));
+        when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
+
+        // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
+        Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
+        oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
+        when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
+        Map<MentionedActorReference, List<String>> newCounts = new HashMap<>();
+        newCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor1", "anchor2"));
+        when(this.xdomService.groupAnchorsByUserReference(newMentions)).thenReturn(newCounts);
+
+        List<MentionNotificationParameters> analyze =
+            this.updatedDocumentMentionsAnalyzer.analyze(oldDoc, newDoc, DOCUMENT_REFERENCE, "1.1", AUTHOR);
+
+        assertEquals(List.of(
+            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference(TEXT_FIELD, oldObject.getReference()),
+
+=====================================================================
+Found a 24 line (235 tokens) duplication in the following files: 
+Starting at line 280 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPluginTest.java
+Starting at line 174 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPluginTest.java
+
+        DocumentReference documentReference2 = new DocumentReference("xwiki", "MySpace", "MyOtherSSXPage");
+
+        when(this.currentEntityReferenceResolver.resolve(resource2, EntityType.DOCUMENT))
+            .thenReturn(documentReference2);
+        when(this.entityReferenceSerializer.serialize(documentReference2)).thenReturn(resource2);
+
+        when(this.documentReferenceResolver.resolve(resource2)).thenReturn(documentReference2);
+        XWikiDocument document2 = mock(XWikiDocument.class);
+        when(this.mockitoOldcore.getSpyXWiki().getDocument(documentReference2, context)).thenReturn(document2);
+
+        DocumentReference userReference2 = new DocumentReference("xwiki", "XWiki", "Bar");
+        when(document2.getAuthorReference()).thenReturn(userReference2);
+        when(this.authorizationManager.hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference2,
+            documentReference2)).thenReturn(false);
+
+        this.skinExtensionPlugin.use(resource2, parameters2, context);
+        resources = (Set<String>) context.get(className);
+        assertEquals(Collections.singleton(resource), resources);
+        parametersMap =
+            (Map<String, Map<String, Object>>) context.get(className + "_parameters");
+        assertEquals(expectedParameters, parametersMap);
+        verify(this.authorizationManager).hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference2,
+            documentReference2);
+        verify(this.skinExtensionAsync, never()).use("ssx", resource2, parameters2);
+
+=====================================================================
+Found a 29 line (234 tokens) duplication in the following files: 
+Starting at line 83 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/observation/remote/converter/DocumentEventConverterTest.java
+Starting at line 122 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/observation/remote/converter/DocumentEventConverterTest.java
+
+        localEvent.setSource(document);
+        localEvent.setData(this.oldcore.getXWikiContext());
+
+        RemoteEventData remoteEvent = this.converterManager.createRemoteEventData(localEvent);
+
+        assertFalse(remoteEvent.getSource() instanceof XWikiDocument);
+        assertFalse(remoteEvent.getData() instanceof XWikiContext);
+
+        // serialize/unserialize
+        ByteArrayOutputStream sos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(sos);
+        oos.writeObject(remoteEvent);
+        ByteArrayInputStream sis = new ByteArrayInputStream(sos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(sis);
+        remoteEvent = (RemoteEventData) ois.readObject();
+
+        // remote -> local
+
+        LocalEventData localEvent2 = this.converterManager.createLocalEventData(remoteEvent);
+
+        assertTrue(localEvent2.getSource() instanceof XWikiDocument);
+        assertTrue(localEvent2.getData() instanceof XWikiContext);
+        assertEquals(documentReference, ((XWikiDocument) localEvent2.getSource()).getDocumentReference());
+        assertEquals("space", ((XWikiDocument) localEvent2.getSource()).getSpaceName());
+        assertEquals("page", ((XWikiDocument) localEvent2.getSource()).getPageName());
+        assertTrue(((XWikiDocument) localEvent2.getSource()).getOriginalDocument().isNew());
+        assertNotSame(this.oldcore.getSpyXWiki().getDocument(documentReference, this.oldcore.getXWikiContext()),
+            localEvent2.getSource());
+    }
+
+=====================================================================
+Found a 32 line (232 tokens) duplication in the following files: 
+Starting at line 84 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/configuration/GeneralMailConfigClassDocumentConfigurationSourceTest.java
+Starting at line 84 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/configuration/SendMailConfigClassDocumentConfigurationSourceTest.java
+
+        LocalDocumentReference classReference = new LocalDocumentReference("Mail", "GeneralMailConfigClass");
+
+        BaseProperty property = mock(BaseProperty.class);
+        when(property.toText()).thenReturn("value");
+
+        BaseObject object = mock(BaseObject.class);
+        when(object.getField("key")).thenReturn(property);
+
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getXObject(classReference)).thenReturn(object);
+
+        DocumentReference documentReference = new DocumentReference("wiki", "Mail", "MailConfig");
+        XWiki xwiki = mock(XWiki.class);
+        when(xwiki.getDocument(eq(documentReference), any(XWikiContext.class))).thenReturn(document);
+
+        XWikiContext xcontext = mock(XWikiContext.class);
+        when(xcontext.getWiki()).thenReturn(xwiki);
+
+        when(this.xcontextProvider.get()).thenReturn(xcontext);
+
+        assertEquals("value", this.source.getProperty("key", "defaultValue"));
+    }
+
+    @Test
+    void getPropertyWhenNoSendMailConfigClassXObject() throws Exception
+    {
+        Cache<Object> cache = mock(Cache.class);
+        when(this.cacheManager.createNewCache(any(CacheConfiguration.class))).thenReturn(cache);
+
+        when(this.wikiDescriptorManager.getCurrentWikiId()).thenReturn("wiki");
+
+        LocalDocumentReference classReference = new LocalDocumentReference("Mail", "GeneralMailConfigClass");
+
+=====================================================================
+Found a 27 line (231 tokens) duplication in the following files: 
+Starting at line 375 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 415 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+            any(NotificationPreference.class))).thenReturn(new ForUserNode(USER_REFERENCE, true));
+        when(notificationFilter1.matchesPreference(any(NotificationPreference.class))).thenReturn(true);
+        when(this.notificationFilterManager.getFiltersRelatedToNotificationPreference(anyCollection(),
+            any(NotificationPreference.class)))
+                .thenAnswer(invocationOnMock -> ((Collection) invocationOnMock.getArgument(0)).stream());
+
+        // Test
+        NotificationParameters parameters = new NotificationParameters();
+        parameters.user = USER_REFERENCE;
+        parameters.format = NotificationFormat.ALERT;
+        parameters.fromDate = this.startDate;
+        parameters.filters = Arrays.asList(notificationFilter1);
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new StatusQueryCondition(USER_REFERENCE.toString(), true, false), conditions.next());
+
+=====================================================================
+Found a 37 line (227 tokens) duplication in the following files: 
+Starting at line 93 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+Starting at line 296 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+
+        byte[] zipFile = this.createZipFile(new XWikiDocument[] { doc1 }, new String[] { "ISO-8859-1" }, null);
+
+        // make sure no data is in the packager from the other tests run
+        this.pack = new Package();
+        // import and install this document
+        this.pack.Import(zipFile, this.oldcore.getXWikiContext());
+        this.pack.install(this.oldcore.getXWikiContext());
+
+        // check if it is there
+        XWikiDocument foundDocument =
+            this.xwiki.getDocument(new LocalDocumentReference("Test", "DocImport"), this.oldcore.getXWikiContext());
+        assertFalse(foundDocument.isNew());
+
+        XWikiDocument nonExistingDocument = this.xwiki
+            .getDocument(new LocalDocumentReference("Test", "DocImportNonexisting"), this.oldcore.getXWikiContext());
+        assertTrue(nonExistingDocument.isNew());
+
+        XWikiDocument foundTranslationDocument =
+            foundDocument.getTranslatedDocument("fr", this.oldcore.getXWikiContext());
+        assertSame(foundDocument, foundTranslationDocument);
+
+        XWikiDocument doc1Translation =
+            new XWikiDocument(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Test", "DocImport"));
+        doc1Translation.setLanguage("fr");
+        doc1Translation.setDefaultLanguage("en");
+        this.xwiki.saveDocument(doc1Translation, this.oldcore.getXWikiContext());
+        foundTranslationDocument = foundDocument.getTranslatedDocument("fr", this.oldcore.getXWikiContext());
+        assertNotSame(foundDocument, foundTranslationDocument);
+    }
+
+    /**
+     * Test the regular document import when the XAR is tagged as extension.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testImportExtension() throws Exception
+
+=====================================================================
+Found a 24 line (226 tokens) duplication in the following files: 
+Starting at line 165 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultMacroRefactoringTest.java
+Starting at line 241 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultMacroRefactoringTest.java
+
+    {
+        when(this.contentDescriptor.getType()).thenReturn(Block.LIST_BLOCK_TYPE);
+        when(this.macroBlock.isInline()).thenReturn(false);
+        String macroContent = "some macro content";
+        when(this.macroBlock.getContent()).thenReturn(macroContent);
+
+        XDOM xdom = mock(XDOM.class);
+        when(this.macroContentParser.getCurrentSyntax(any())).thenAnswer(invocationOnMock -> {
+            MacroTransformationContext transformationContext = invocationOnMock.getArgument(0);
+            assertEquals(transformationContext.getId(), "refactoring_" + macroId);
+            assertEquals(macroBlock, transformationContext.getCurrentMacroBlock());
+            assertEquals(this.syntax, transformationContext.getSyntax());
+            assertFalse(transformationContext.isInline());
+            return this.syntax;
+        });
+        when(this.macroContentParser.parse(eq(macroContent), any(), eq(true), eq(false)))
+            .thenAnswer(invocationOnMock -> {
+            MacroTransformationContext transformationContext = invocationOnMock.getArgument(1);
+            assertEquals(transformationContext.getId(), "refactoring_" + macroId);
+            assertEquals(macroBlock, transformationContext.getCurrentMacroBlock());
+            assertEquals(this.syntax, transformationContext.getSyntax());
+            assertFalse(transformationContext.isInline());
+            return xdom;
+        });
+
+=====================================================================
+Found a 22 line (222 tokens) duplication in the following files: 
+Starting at line 125 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentEntityReferenceProviderTest.java
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentReferenceEntityReferenceResolverTest.java
+
+        this.mockitoOldcore.getXWikiContext().setWikiId(null);
+
+        when(this.configuration.getDefaultReferenceValue(EntityType.WIKI)).thenReturn(DEFAULT_WIKI);
+        when(this.configuration.getDefaultReferenceValue(EntityType.SPACE)).thenReturn(DEFAULT_SPACE);
+        when(this.configuration.getDefaultReferenceValue(EntityType.DOCUMENT)).thenReturn(DEFAULT_DOCUMENT);
+        when(this.configuration.getDefaultReferenceValue(EntityType.OBJECT)).thenReturn(DEFAULT_OBJECT);
+        when(this.configuration.getDefaultReferenceValue(EntityType.OBJECT_PROPERTY))
+            .thenReturn(DEFAULT_OBJECT_PROPERTY);
+        when(this.configuration.getDefaultReferenceValue(EntityType.CLASS_PROPERTY)).thenReturn(DEFAULT_CLASS_PROPERTY);
+        when(this.configuration.getDefaultReferenceValue(EntityType.ATTACHMENT)).thenReturn(DEFAULT_ATTACHMENT);
+        when(this.configuration.getDefaultReferenceValue(EntityType.PAGE)).thenReturn(DEFAULT_PAGE);
+        when(this.configuration.getDefaultReferenceValue(EntityType.PAGE_OBJECT)).thenReturn(DEFAULT_PAGE_OBJECT);
+        when(this.configuration.getDefaultReferenceValue(EntityType.PAGE_OBJECT_PROPERTY))
+            .thenReturn(DEFAULT_PAGE_OBJECT_PROPERTY);
+        when(this.configuration.getDefaultReferenceValue(EntityType.PAGE_ATTACHMENT))
+            .thenReturn(DEFAULT_PAGE_ATTACHMENT);
+        when(this.configuration.getDefaultReferenceValue(EntityType.PAGE_CLASS_PROPERTY))
+            .thenReturn(DEFAULT_PAGE_CLASS_PROPERTY);
+    }
+
+    @Test
+    public void getDefaultReferenceWithoutContextDocument()
+
+=====================================================================
+Found a 25 line (218 tokens) duplication in the following files: 
+Starting at line 143 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/test/java/com/xpn/xwiki/plugin/image/ImagePluginTest.java
+Starting at line 214 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/test/java/com/xpn/xwiki/plugin/image/ImagePluginTest.java
+
+    void cacheOfScaledAttachment() throws Exception
+    {
+        Date date = new Date(0);
+
+        XWikiContext xcontext = this.oldCore.getXWikiContext();
+
+        XWikiAttachment attachment = mock(XWikiAttachment.class);
+        when(attachment.getMimeType(xcontext)).thenReturn("image/png");
+        InputStream attachmentInputStream = new ByteArrayInputStream(IMAGE_CONTENT);
+        when(attachment.getContentInputStream(xcontext)).thenReturn(attachmentInputStream);
+        when(attachment.clone()).thenReturn(attachment);
+        when(attachment.getDate()).thenReturn(date);
+
+        XWikiAttachmentContent attachmentContent = mock(XWikiAttachmentContent.class);
+        when(attachment.getAttachment_content()).thenReturn(attachmentContent);
+        when(attachmentContent.getContentInputStream()).thenReturn(attachmentInputStream);
+        OutputStream attachmentOutputStream = mock(OutputStream.class);
+        when(attachmentContent.getContentOutputStream()).thenReturn(attachmentOutputStream);
+
+        CacheManager cacheManager = this.oldCore.getMocker().getInstance(CacheManager.class);
+        Cache<Object> imageCache = mock(Cache.class);
+        when(cacheManager.createNewLocalCache(ArgumentMatchers.any())).thenReturn(imageCache);
+
+        XWikiServletRequest request = mock(XWikiServletRequest.class);
+        when(request.getParameter("width")).thenReturn("30");
+
+=====================================================================
+Found a 73 line (215 tokens) duplication in the following files: 
+Starting at line 106 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+Starting at line 121 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+
+    }
+
+    /**
+     * @return {@code true} if the list box that is used to select the groups should be filled with all the available
+     *         groups, {@code false} otherwise
+     * @deprecated since 4.3M2 this meta property is not used anymore because we changed the default displayer
+     */
+    @Deprecated
+    public boolean isUsesList()
+    {
+        return getIntValue(META_PROPERTY_USES_LIST) == 1;
+    }
+
+    /**
+     * Sets whether to list all the available groups in the list box used to select the groups. This property should not
+     * be set when the number of groups is very large.
+     *
+     * @param usesList {@code true} to fill the list box that is used to select the groups with all the available
+     *            groups, {@code false} otherwise
+     * @deprecated since 4.3M2 this meta property is not used anymore because we changed the default displayer
+     */
+    @Deprecated
+    public void setUsesList(boolean usesList)
+    {
+        setIntValue(META_PROPERTY_USES_LIST, usesList ? 1 : 0);
+    }
+
+    @Override
+    public BaseProperty newProperty()
+    {
+        // If the property type should ever change, the logic in UsedValuesListQueryBuilder and LiveTableResultsMacros
+        // might need to be updated.
+        BaseProperty property = new LargeStringProperty();
+        property.setName(getName());
+        return property;
+    }
+
+    @Override
+    public BaseProperty fromString(String value) throws XWikiException
+    {
+        BaseProperty prop = newProperty();
+        prop.setValue(value);
+        return prop;
+    }
+
+    @Override
+    public BaseProperty fromStringArray(String[] strings)
+    {
+        List<String> list;
+        if ((strings.length == 1) && (getDisplayType().equals(DISPLAYTYPE_INPUT) || isMultiSelect())) {
+            list = getListFromString(strings[0], getSeparators(), false);
+        } else {
+            list = Arrays.asList(strings);
+        }
+
+        BaseProperty prop = newProperty();
+        fromList(prop, list);
+        return prop;
+    }
+
+    @Override
+    public void fromList(BaseProperty<?> property, List<String> list)
+    {
+        fromList(property, list, true);
+    }
+
+    /**
+     * @param value a group string reference
+     * @param context the XWiki context
+     * @return the name of the specified group (the document name component from the given reference)
+     */
+    public String getText(String value, XWikiContext context)
+    {
+
+=====================================================================
+Found a 24 line (215 tokens) duplication in the following files: 
+Starting at line 608 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 668 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+        DocumentReference newLinkTarget = new DocumentReference("wiki", "X", "WebHome");
+
+        XDOM xdom = mock(XDOM.class);
+        when(document.getXDOM()).thenReturn(xdom);
+
+        ResourceReference docLinkReference = new ResourceReference("A.WebHome", ResourceType.DOCUMENT);
+        LinkBlock documentLinkBlock = new LinkBlock(List.of(), docLinkReference, false);
+        EntityReference relativeReference = new EntityReference("WebHome", EntityType.DOCUMENT,
+            new EntityReference("A", EntityType.SPACE));
+
+        ResourceReference spaceLinkReference = new ResourceReference("A", ResourceType.SPACE);
+        LinkBlock spaceLinkBlock = new LinkBlock(List.of(), spaceLinkReference, false);
+        EntityReference relativeSpaceReference = new EntityReference("A", EntityType.SPACE);
+
+        when(xdom.getBlocks(any(), eq(Block.Axes.DESCENDANT)))
+            .thenReturn(List.of(documentLinkBlock, spaceLinkBlock));
+
+        // Doc link
+        when(this.resourceReferenceResolver.resolve(docLinkReference, null))
+            .thenReturn(oldLinkTarget);
+        when(this.resourceReferenceResolver.resolve(docLinkReference, null, documentReference))
+            .thenReturn(oldLinkTarget);
+        when(this.defaultReferenceDocumentReferenceResolver.resolve(oldLinkTarget)).thenReturn(oldLinkTarget);
+        when(this.compactEntityReferenceSerializer.serialize(newLinkTarget, documentReference)).thenReturn("X.WebHome");
+
+=====================================================================
+Found a 27 line (214 tokens) duplication in the following files: 
+Starting at line 121 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 171 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+    void getFilterPreferencesNoFilterSort() throws QueryException, LiveDataException
+    {
+        String owner = "xwiki:XWiki.Foo";
+        String wikiName = "foo";
+        WikiReference wikiReference = new WikiReference(wikiName);
+        Long offset = 3L;
+        int limit = 12;
+
+        LiveDataQuery ldQuery = mock(LiveDataQuery.class);
+        when(ldQuery.getOffset()).thenReturn(offset);
+        when(ldQuery.getLimit()).thenReturn(limit);
+
+        LiveDataQuery.SortEntry sortEntry1 = mock(LiveDataQuery.SortEntry.class, "sortEntry1");
+        when(sortEntry1.isDescending()).thenReturn(false);
+        when(sortEntry1.getProperty()).thenReturn("scope");
+
+        LiveDataQuery.SortEntry sortEntry2 = mock(LiveDataQuery.SortEntry.class, "sortEntry2");
+        when(sortEntry2.isDescending()).thenReturn(true);
+        when(sortEntry2.getProperty()).thenReturn("isEnabled");
+
+        LiveDataQuery.SortEntry sortEntry3 = mock(LiveDataQuery.SortEntry.class, "sortEntry3");
+        when(sortEntry3.isDescending()).thenReturn(true);
+        when(sortEntry3.getProperty()).thenReturn("notificationFormats");
+
+        when(ldQuery.getSort()).thenReturn(List.of(sortEntry1, sortEntry2, sortEntry3));
+
+        String queryString = "select nfp from DefaultNotificationFilterPreference nfp where owner = :owner "
+
+=====================================================================
+Found a 22 line (212 tokens) duplication in the following files: 
+Starting at line 154 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/AuthenticationMailSenderTest.java
+Starting at line 226 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/AuthenticationMailSenderTest.java
+
+        when(this.mailSenderConfiguration.getFromAddress()).thenReturn(fromAdress);
+        when(xWikiContext.getLocale()).thenReturn(Locale.CANADA);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("from", fromAdress);
+        parameters.put("to", email);
+        parameters.put("language", Locale.CANADA);
+        parameters.put("type", "Reset Password");
+        Map<String, String> velocityVariables = new HashMap<>();
+        velocityVariables.put("userName", username);
+        velocityVariables.put("passwordResetURL", resetPasswordUrl.toExternalForm());
+        parameters.put("velocityVariables", velocityVariables);
+
+        Session session = Session.getInstance(new Properties());
+        when(this.sessionFactory.create(Collections.emptyMap())).thenReturn(session);
+        MimeMessage message = mock(MimeMessage.class);
+
+        when(this.mimeMessageFactory.createMessage(templateDocumentReference, parameters))
+            .thenReturn(message);
+        MailStatusResult mailStatusResult = mock(MailStatusResult.class);
+        when(this.mailListener.getMailStatusResult()).thenReturn(mailStatusResult);
+        MailStatus mailStatus = mock(MailStatus.class);
+
+=====================================================================
+Found a 26 line (210 tokens) duplication in the following files: 
+Starting at line 158 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
+Starting at line 339 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
+
+        when(this.contextualAuthorizationManager.hasAccess(Right.ADMIN)).thenReturn(true);
+        when(context.getUserReference()).thenReturn(userDoc);
+
+        String filter1Name = "filter1";
+        String filter2Name = "filter2";
+        String filter3Name = "filter3";
+        String filter4Name = "filter4";
+        String filter5Name = "filter5";
+        String filter6Name = "filter6";
+        String filter7Name = "filter7";
+
+        NotificationFilter filter1 = mock(NotificationFilter.class, filter1Name);
+        ToggleableNotificationFilter filter2 = mock(ToggleableNotificationFilter.class, filter2Name);
+        NotificationFilter filter3 = mock(NotificationFilter.class, filter3Name);
+        ToggleableNotificationFilter filter4 = mock(ToggleableNotificationFilter.class, filter4Name);
+        ToggleableNotificationFilter filter5 = mock(ToggleableNotificationFilter.class, filter5Name);
+        ToggleableNotificationFilter filter6 = mock(ToggleableNotificationFilter.class, filter6Name);
+        ToggleableNotificationFilter filter7 = mock(ToggleableNotificationFilter.class, filter7Name);
+
+        when(filter1.getName()).thenReturn(filter1Name);
+        when(filter2.getName()).thenReturn(filter2Name);
+        when(filter3.getName()).thenReturn(filter3Name);
+        when(filter4.getName()).thenReturn(filter4Name);
+        when(filter5.getName()).thenReturn(filter5Name);
+        when(filter6.getName()).thenReturn(filter6Name);
+        when(filter7.getName()).thenReturn(filter7Name);
+
+=====================================================================
+Found a 26 line (209 tokens) duplication in the following files: 
+Starting at line 421 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/DocumentTest.java
+Starting at line 563 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/DocumentTest.java
+
+                });
+        }
+        secureDocument.setContentDirty(false);
+        this.oldcore.getSpyXWiki().saveDocument(secureDocument, this.oldcore.getXWikiContext());
+
+        this.oldcore.getXWikiContext()
+            .setDoc(this.oldcore.getSpyXWiki().getDocument(secureDocument.getDocumentReference(),
+                this.oldcore.getXWikiContext()));
+
+        XWikiDocument editedXDocument = new XWikiDocument(new DocumentReference("xwiki", "Space", "Page1"));
+        DocumentReference editedInitialAuthor = new DocumentReference("wiki1", "XWiki", "editedInitialAuthor");
+        editedXDocument.setAuthorReference(editedInitialAuthor);
+        DocumentReference editedInitialContentAuthor =
+            new DocumentReference("wiki1", "XWiki", "editedInitialContentAuthor");
+        editedXDocument.setContentAuthorReference(editedInitialContentAuthor);
+        editedXDocument.setCreatorReference(new DocumentReference("wiki1", "XWiki", "editedCreator"));
+        editedXDocument.setEnforceRequiredRights(enforceOnEditedDocument);
+        if (StringUtils.isNotBlank(rightOnEditedDocument)) {
+            BaseObject requiredRightObject =
+                editedXDocument.newXObject(DocumentRequiredRightsReader.CLASS_REFERENCE,
+                    this.oldcore.getXWikiContext());
+            requiredRightObject.set(DocumentRequiredRightsReader.PROPERTY_NAME, rightOnEditedDocument,
+                this.oldcore.getXWikiContext());
+        }
+        editedXDocument.setContentDirty(false);
+        this.oldcore.getSpyXWiki().saveDocument(editedXDocument, this.oldcore.getXWikiContext());
+
+=====================================================================
+Found a 21 line (209 tokens) duplication in the following files: 
+Starting at line 195 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+Starting at line 257 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+
+        verify(this.criteriaQueryLong).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(4, predicates.size());
+
+        ComparisonPredicate authorPredicate = (ComparisonPredicate) predicates.get(2);
+        LiteralExpression<String> authorExpression = (LiteralExpression<String>) authorPredicate.getRightHandOperand();
+        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, authorPredicate.getComparisonOperator());
+        assertEquals("mocked author", authorPredicate.getLeftHandOperand().toString());
+        assertEquals("TestAuthor", authorExpression.getLiteral());
+
+        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(3);
+        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
+        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        assertEquals("mocked date", datePredicate.getExpression().toString());
+        assertEquals(new Date(0L), dateLowerExpression.getLiteral());
+        assertEquals(new Date(Integer.MAX_VALUE * 1000L), dateUpperExpression.getLiteral());
+    }
+
+    @Test
+    void testRCSNodeInfoCountQueryWithDateCriteria()
+
+=====================================================================
+Found a 21 line (208 tokens) duplication in the following files: 
+Starting at line 106 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/XObjectAverageRatingManagerTest.java
+Starting at line 159 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/XObjectAverageRatingManagerTest.java
+
+    void getAverageRating() throws Exception
+    {
+        String managerId = "myRatings";
+        when(this.ratingsManager.getIdentifier()).thenReturn(managerId);
+        DocumentReference reference = new DocumentReference("xwiki","XWiki", "Foo");
+        XWikiDocument xWikiDocument = mock(XWikiDocument.class);
+        when(xWikiDocument.clone()).thenReturn(xWikiDocument);
+        when(xWikiDocument.getDocumentReference()).thenReturn(reference);
+        when(this.documentAccessBridge.getDocumentInstance(new EntityReference(reference))).thenReturn(xWikiDocument);
+        when(this.entityReferenceConverter.convert(String.class, reference)).thenReturn("document:xwiki:XWiki.Foo");
+        BaseObject averageRating1 = mock(BaseObject.class);
+        BaseObject averageRating2 = mock(BaseObject.class);
+
+        when(xWikiDocument.getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
+            .thenReturn(asList(averageRating1, averageRating2));
+        when(averageRating1.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
+            .thenReturn("something");
+        when(averageRating2.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
+            .thenReturn(managerId);
+        when(averageRating2.getStringValue(AverageRatingQueryField.ENTITY_REFERENCE.getFieldName()))
+            .thenReturn("document:xwiki:XWiki.Foo");
+
+=====================================================================
+Found a 17 line (207 tokens) duplication in the following files: 
+Starting at line 160 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/ModelBridgeTest.java
+Starting at line 187 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/ModelBridgeTest.java
+
+        DocumentReference documentReference = new DocumentReference("xwiki", "MyApp", "mydoc");
+        DocumentReference classReference = new DocumentReference("xwiki", "MyApp", "MyClass");
+
+        when(this.xwiki.getDocument(documentReference, this.xcontext)).thenReturn(this.document);
+        when(this.document.getXObject(classReference, 0)).thenReturn(this.baseObject);
+        // The list of properties includes the property to update. 
+        when(this.baseObject.getPropertyNames()).thenReturn(new String[] { "propertyA", "propertyName", "propertyB" });
+        when(this.baseObject.get(property)).thenReturn(this.propertyInterface);
+        when(this.baseObject.getXClass(this.xcontext)).thenReturn(this.baseClass);
+
+        when(this.propertyInterface.toFormString()).thenReturn("updatedValue");
+        when(this.document.validate(this.xcontext)).thenReturn(true);
+        when(this.document.isContentDirty()).thenReturn(true);
+
+        Optional<Object> update = this.modelBridge.update(property, value, documentReference, classReference);
+        
+        assertEquals("updatedValue", update.get());
+
+=====================================================================
+Found a 22 line (207 tokens) duplication in the following files: 
+Starting at line 296 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 327 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+
+    void checkGoodVerificationCodeTokenLifetimeNotExpired() throws Exception
+    {
+        when(this.userManager.exists(this.userReference)).thenReturn(true);
+        InternetAddress email = new InternetAddress("foobar@xwiki.org");
+        when(this.userProperties.getEmail()).thenReturn(email);
+        String verificationCode = "abcd1245";
+        BaseObject xObject = mock(BaseObject.class);
+        when(this.userDocument
+            .getXObject(ResetPasswordRequestClassDocumentInitializer.REFERENCE))
+            .thenReturn(xObject);
+        String encodedVerificationCode = "encodedVerificationCode";
+        when(xObject.getStringValue(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD))
+            .thenReturn(encodedVerificationCode);
+        BaseClass baseClass = mock(BaseClass.class);
+        when(xObject.getXClass(context)).thenReturn(baseClass);
+        PasswordClass passwordClass = mock(PasswordClass.class);
+        when(baseClass.get(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD)).thenReturn(passwordClass);
+        when(passwordClass.getEquivalentPassword(encodedVerificationCode, verificationCode))
+            .thenReturn(encodedVerificationCode);
+        when(this.configurationSource.getProperty(DefaultResetPasswordManager.TOKEN_LIFETIME, 60)).thenReturn(15);
+        when(xObject.getDateValue(ResetPasswordRequestClassDocumentInitializer.REQUEST_DATE_FIELD))
+            .thenReturn(Date.from(Instant.now().minus(14, ChronoUnit.MINUTES)));
+
+=====================================================================
+Found a 18 line (206 tokens) duplication in the following files: 
+Starting at line 535 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+Starting at line 620 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+
+        when(response.getResults()).thenReturn(this.documentList);
+
+        Map<String, Object> fieldMap = new HashMap<>();
+        fieldMap.put("id", "myRating");
+        fieldMap.put(RatingQueryField.VOTE.getFieldName(), oldVote);
+        fieldMap.put(RatingQueryField.CREATED_DATE.getFieldName(), new Date(422));
+        fieldMap.put(RatingQueryField.UPDATED_DATE.getFieldName(), new Date(422));
+        fieldMap.put(RatingQueryField.USER_REFERENCE.getFieldName(), "user:Toto");
+        fieldMap.put(RatingQueryField.ENTITY_REFERENCE.getFieldName(), "wiki:Space.Page");
+        fieldMap.put(RatingQueryField.SCALE.getFieldName(), scale);
+        fieldMap.put(RatingQueryField.MANAGER_ID.getFieldName(), managerId);
+
+        SolrDocument solrDocument = new SolrDocument(fieldMap);
+        when(this.solrUtils.get(RatingQueryField.ENTITY_REFERENCE.getFieldName(), solrDocument, EntityReference.class))
+            .thenReturn(reference);
+        when(this.solrUtils.get(RatingQueryField.USER_REFERENCE.getFieldName(), solrDocument, UserReference.class))
+            .thenReturn(userReference);
+        when(this.documentList.stream()).thenReturn(Collections.singletonList(solrDocument).stream());
+
+=====================================================================
+Found a 30 line (204 tokens) duplication in the following files: 
+Starting at line 577 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+Starting at line 691 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+
+        DeletePageConfirmationPage confirmationPage = parentPage.deletePage();
+        confirmationPage.confirmDeletePage();
+
+        // At this point we should have the question job UI
+        JobQuestionPane jobQuestionPane = new JobQuestionPane().waitForQuestionPane();
+        assertFalse(jobQuestionPane.isEmpty());
+
+        assertEquals("You are about to delete pages that contain used XClass.", jobQuestionPane.getQuestionTitle());
+        TreeElement treeElement = jobQuestionPane.getQuestionTree();
+        List<TreeNodeElement> topLevelNodes = treeElement.getTopLevelNodes();
+
+        // there is a single node for the xclass:
+        //  1. to represent free pages
+        //  2. to represent classes with associated objects
+        assertEquals(1, topLevelNodes.size());
+
+        TreeNodeElement classPage = topLevelNodes.get(0);
+        assertEquals(classPageName, classPage.getLabel());
+        assertEquals(String.format("%s.%s.%s", space, xclassSpace, classPageName), classPage.getId());
+        assertFalse(classPage.isSelected());
+
+        classPage = classPage.open().waitForIt();
+        List<TreeNodeElement> children = classPage.getChildren();
+        assertEquals(1, children.size());
+
+        assertEquals(objectPageName, children.get(0).getLabel());
+
+        // here it's an object
+        assertEquals(String.format("object-%s.%s.%s", space, xobjectSpace, objectPageName), children.get(0).getId());
+        assertTrue(children.get(0).isLeaf());
+
+=====================================================================
+Found a 28 line (204 tokens) duplication in the following files: 
+Starting at line 93 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+Starting at line 153 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+Starting at line 296 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+
+        byte[] zipFile = this.createZipFile(new XWikiDocument[] { doc1 }, new String[] { "ISO-8859-1" }, null);
+
+        // make sure no data is in the packager from the other tests run
+        this.pack = new Package();
+        // import and install this document
+        this.pack.Import(zipFile, this.oldcore.getXWikiContext());
+        this.pack.install(this.oldcore.getXWikiContext());
+
+        // check if it is there
+        XWikiDocument foundDocument =
+            this.xwiki.getDocument(new LocalDocumentReference("Test", "DocImport"), this.oldcore.getXWikiContext());
+        assertFalse(foundDocument.isNew());
+
+        XWikiDocument nonExistingDocument = this.xwiki
+            .getDocument(new LocalDocumentReference("Test", "DocImportNonexisting"), this.oldcore.getXWikiContext());
+        assertTrue(nonExistingDocument.isNew());
+
+        XWikiDocument foundTranslationDocument =
+            foundDocument.getTranslatedDocument("fr", this.oldcore.getXWikiContext());
+        assertSame(foundDocument, foundTranslationDocument);
+
+        XWikiDocument doc1Translation =
+            new XWikiDocument(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Test", "DocImport"));
+        doc1Translation.setLanguage("fr");
+        doc1Translation.setDefaultLanguage("en");
+        this.xwiki.saveDocument(doc1Translation, this.oldcore.getXWikiContext());
+        foundTranslationDocument = foundDocument.getTranslatedDocument("fr", this.oldcore.getXWikiContext());
+        assertNotSame(foundDocument, foundTranslationDocument);
+
+=====================================================================
+Found a 22 line (202 tokens) duplication in the following files: 
+Starting at line 449 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 477 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        ApplicationPreferences system = notificationsUserProfilePage.getApplication(SYSTEM);
+        assertTrue(system.isCollapsed());
+        system.setCollapsed(false);
+
+        // Check default values
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, EMAIL_FORMAT));
+
+        assertEquals(NotificationsUserProfilePage.EmailDiffType.STANDARD,
+            notificationsUserProfilePage.getNotificationEmailDiffType());
+        assertEquals(NotificationsUserProfilePage.AutowatchMode.MAJOR,
+            notificationsUserProfilePage.getAutoWatchModeValue());
+
+        notificationsUserProfilePage.setEventTypeState(SYSTEM, CREATE, ALERT_FORMAT, OFF);
+
+=====================================================================
+Found a 24 line (201 tokens) duplication in the following files: 
+Starting at line 112 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/test/java/org/xwiki/mail/internal/DatabaseMailResenderTest.java
+Starting at line 154 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/test/java/org/xwiki/mail/internal/DatabaseMailResenderTest.java
+
+    void resendAsynchronouslySeveralMessages() throws Exception
+    {
+        Map<String, Object> filterMap = Collections.singletonMap("state", "prepare_%");
+
+        MailStatus status1 = new MailStatus();
+        status1.setBatchId("batch1");
+        status1.setMessageId("message1");
+
+        MailStatus status2 = new MailStatus();
+        status2.setBatchId("batch2");
+        status2.setMessageId("message2");
+
+        List<MailStatus> statuses = new ArrayList<>();
+        statuses.add(status1);
+        statuses.add(status2);
+
+        MailStatusStore statusStore = this.componentManager.getInstance(MailStatusStore.class, "database");
+        when(statusStore.load(filterMap, 0, 0, null, true)).thenReturn(statuses);
+
+        MailContentStore contentStore = this.componentManager.getInstance(MailContentStore.class, "filesystem");
+        ExtendedMimeMessage message1 = new ExtendedMimeMessage();
+        when(contentStore.load(any(), eq("batch1"), eq("message1"))).thenReturn(message1);
+        ExtendedMimeMessage message2 = new ExtendedMimeMessage();
+        when(contentStore.load(any(), eq("batch2"), eq("message2"))).thenReturn(message2);
+
+=====================================================================
+Found a 25 line (199 tokens) duplication in the following files: 
+Starting at line 74 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/util/XWikiIconProviderTest.java
+Starting at line 139 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/util/XWikiIconProviderTest.java
+
+        currentIconSet.addIcon("test", new Icon("hello"));
+        when(iconSetManager.getCurrentIconSet()).thenReturn(currentIconSet);
+        when(iconSetManager.getDefaultIconSet()).thenReturn(defaultIconSet);
+
+        // Mock behaviour for the iconRenderer
+        String testIconFA = "<span class=\"fa fa-test\"aria-hidden=\"true\"></span>";
+        String testIconSilk = "<img src=\"$xwiki.getSkinFile(\"icons/silk/test.png\")\" alt=\"\" " +
+            "data-xwiki-lightbox=\"false\" />";
+        when(this.iconRenderer.renderHTML("test", currentIconSet)).thenReturn(testIconFA);
+        when(this.iconRenderer.renderHTML("test", defaultIconSet)).thenReturn(testIconSilk);
+        // Mock behaviour for the LocalizationManager
+        Block translationRendered = new CompositeBlock();
+        translationRendered.addChild(new WordBlock("Test translation"));
+        when(l10n.getTranslation("rendering.icon.provider.icon.alternative.test")).thenReturn(translationResult);
+        when(translationResult.render()).thenReturn(translationRendered);
+
+        // Test
+        Block result = iconProvider.get("test");
+        assertEquals(FormatBlock.class, result.getClass());
+        assertEquals("icon-block", result.getParameter("class"));
+        List<Block> children = result.getChildren();
+        assertEquals(1, children.size());
+        assertEquals(RawBlock.class, children.get(0).getClass());
+        // We check the icon itself
+        assertEquals(testIconFA, ((RawBlock) children.get(0)).getRawContent());
+
+=====================================================================
+Found a 18 line (197 tokens) duplication in the following files: 
+Starting at line 683 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 765 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        setFilter("name", "filtername");
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+        when(this.query.execute()).thenReturn(singletonList("Space.MyObject"));
+
+        renderPage();
+
+        List<Map<String, Object>> rows = getRows();
+        assertEquals(expectedMail, StringUtils.trim((String) rows.get(0).get("mail")));
+        assertEquals(expectedMailValue, rows.get(0).get("mail_value"));
+
+        verify(this.queryService).hql(expectedHql);
+        verify(this.query).bindValues(expectedBindValues);
+    }
+
+=====================================================================
+Found a 27 line (195 tokens) duplication in the following files: 
+Starting at line 276 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 386 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 629 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+            + "and ((nfp.pageOnly like :constraint_0 or nfp.page like :constraint_0 or nfp.wiki like :constraint_0 or "
+            + "nfp.user like :constraint_0) or (nfp.pageOnly like :constraint_1 or nfp.page like :constraint_1 or "
+            + "nfp.wiki like :constraint_1 or nfp.user like :constraint_1) or (nfp.pageOnly = :constraint_2 or "
+            + "nfp.page = :constraint_2 or nfp.wiki = :constraint_2 or nfp.user = :constraint_2)) and "
+            + "length(nfp.allEventTypes) = 0 and nfp.enabled = true and length(nfp.pageOnly) > 0 and "
+            + "nfp.filterType = :filterType";
+
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery(queryString, Query.HQL)).thenReturn(query);
+        when(query.bindValue("owner", owner)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter1 = new DefaultQueryParameter(null);
+        queryParameter1.literal("foo").anyChars();
+        when(query.bindValue("constraint_0", queryParameter1)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter2 = new DefaultQueryParameter(null);
+        queryParameter2.anyChars().literal("bar").anyChars();
+        when(query.bindValue("constraint_1", queryParameter2)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter3 = new DefaultQueryParameter(null);
+        queryParameter3.literal("buz");
+        when(query.bindValue("constraint_2", queryParameter3)).thenReturn(query);
+
+        when(query.bindValue("filterType", NotificationFilterType.INCLUSIVE)).thenReturn(query);
+
+        when(query.setWiki(wikiName)).thenReturn(query);
+        when(query.setOffset(offset.intValue())).thenReturn(query);
+
+=====================================================================
+Found a 35 line (194 tokens) duplication in the following files: 
+Starting at line 1076 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1113 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+            new DocumentReference("Y", new SpaceReference("X", new WikiReference("xwiki")));
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(true);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
+        String templateProviderFullName = "XWiki.MyTemplateProvider";
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+
+        // Mock 1 existing template provider
+        mockExistingTemplateProviders(templateProviderFullName,
+            new DocumentReference("xwiki", Arrays.asList("XWiki"), "MyTemplateProvider"),
+            Arrays.asList("AnythingButX"));
+
+        // Run the action
+        String result = action.render(context);
+
+        // The tests are below this line!
+
+        // Verify that the create template is rendered, so the UI is displayed for the user to see the error.
+        assertEquals("create", result);
+
+        // Check that the exception is properly set in the context for the UI to display.
+        XWikiException exception = (XWikiException) this.oldcore.getScriptContext().getAttribute("createException");
+        assertNotNull(exception);
+        assertEquals(XWikiException.ERROR_XWIKI_APP_TEMPLATE_NOT_AVAILABLE, exception.getCode());
+
+        // We should not get this far so no redirect should be done, just the template will be rendered.
+        verify(mockURLFactory, never()).createURL(any(), any(), any(), any(), any(), any(), any(XWikiContext.class));
+    }
+
+    @Test
+    void newDocumentWebHomeFromURLTemplateProviderSpecifiedButNotAllowed() throws Exception
+
+=====================================================================
+Found a 33 line (192 tokens) duplication in the following files: 
+Starting at line 72 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/CurrentDocumentStringUserReferenceResolverTest.java
+Starting at line 69 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DefaultDocumentStringUserReferenceResolverTest.java
+
+        when(this.documentReferenceResolver.resolve(any(), eq(new EntityReference("XWiki", EntityType.SPACE))))
+            .thenAnswer(invocationOnMock -> {
+                String pageName = invocationOnMock.getArgument(0);
+                String spaceName = "XWiki";
+                String wikiName = "wiki";
+                if (pageName.contains(":")) {
+                    String[] split = pageName.split(":");
+                    wikiName = split[0];
+                    pageName = split[1];
+                }
+                if (pageName.contains(".")) {
+                    String[] split = pageName.split("\\.");
+                    spaceName = split[0];
+                    pageName = split[1];
+                }
+                return new DocumentReference(wikiName, spaceName, pageName);
+            });
+    }
+
+    @Test
+    void resolveWithoutParameter()
+    {
+        UserReference reference = this.resolver.resolve("page");
+        assertNotNull(reference);
+        assertTrue(reference instanceof DocumentUserReference);
+        assertEquals("wiki:XWiki.page", ((DocumentUserReference) reference).getReference().toString());
+        assertTrue(reference.isGlobal());
+    }
+
+    @Test
+    void resolveWithParameter()
+    {
+        when(this.documentReferenceResolver.resolve("page", new EntityReference("XWiki", EntityType.SPACE,
+
+=====================================================================
+Found a 20 line (191 tokens) duplication in the following files: 
+Starting at line 181 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManagerTest.java
+Starting at line 203 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManagerTest.java
+
+        HttpServletRequest request = getRequest("customId");
+        assertFalse(this.defaultAuthenticationFailureManager.recordAuthenticationFailure(this.failingLogin, request));
+        assertFalse(this.defaultAuthenticationFailureManager.recordAuthenticationFailure(this.failingLogin, request));
+        assertTrue(this.defaultAuthenticationFailureManager.recordAuthenticationFailure(this.failingLogin, request));
+        assertTrue(this.defaultAuthenticationFailureManager.recordAuthenticationFailure(this.failingLogin, request));
+
+        verify(this.observationManager, times(4)).notify(new AuthenticationFailureEvent(), this.failingLogin);
+        verify(this.observationManager, times(2)).notify(new AuthenticationFailureLimitReachedEvent(),
+            this.failingLogin);
+        verify(this.strategy1, times(2)).notify(failingLogin);
+        verify(this.strategy2, times(2)).notify(failingLogin);
+        verify(this.sessionFailing, times(2)).set(eq("customId"), any(Instant.class));
+        verify(this.sessionFailing, times(4)).get("customId");
+    }
+
+    /**
+     * Ensure that the time window accepts big values (detect possible int/long problems)
+     */
+    @Test
+    void authenticationFailureLimitReachedBigTimeWindow()
+
+=====================================================================
+Found a 29 line (190 tokens) duplication in the following files: 
+Starting at line 545 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+Starting at line 623 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+
+    {
+        // Create 2 pages in two locations:
+        // first page is an xclass that we'll try to delete
+        // second page will contain an xobject of the created xclass
+
+        String testClassName = info.getTestClass().get().getSimpleName();
+        String testMethodName = info.getTestMethod().get().getName();
+        String xclassSpace = "XClassSpace";
+        String xobjectSpace = "XObjectSpace";
+        List<String> xclassSpaceReference = Arrays.asList(testClassName, testMethodName, xclassSpace);
+        DocumentReference xclassReference = new DocumentReference("xwiki",
+            xclassSpaceReference,
+            "WebHome");
+        List<String> xobjectSpaceReference = Arrays.asList(testClassName, testMethodName, xobjectSpace);
+        DocumentReference xobjectReference = new DocumentReference("xwiki",
+            xobjectSpaceReference,
+            "WebHome");
+        String space = testClassName + "." + testMethodName;
+        String classPageName = "ClassPage";
+        String objectPageName = "ObjectPage";
+
+        DocumentReference classReference = new DocumentReference("xwiki", xclassSpaceReference, classPageName);
+        DocumentReference objectReference = new DocumentReference("xwiki", xobjectSpaceReference, objectPageName);
+
+        setup.createPage(classReference, "XClass page content", classPageName);
+        setup.createPage(objectReference, "XObject page content", objectPageName);
+
+        setup.addClassProperty(space, classPageName, "Foo", "String");
+        setup.addObject(objectReference, classReference.toString(), Collections.singletonMap("Foo", "Bar"));
+
+=====================================================================
+Found a 17 line (189 tokens) duplication in the following files: 
+Starting at line 254 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/test/java/org/xwiki/notifications/sources/internal/QueryGeneratorTest.java
+Starting at line 236 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+    public void generateQueryWithFilters() throws Exception
+    {
+        // Mocks
+        NotificationFilter notificationFilter1 = mock(NotificationFilter.class);
+        NotificationFilter notificationFilter2 = mock(NotificationFilter.class);
+
+        when(notificationFilter1.filterExpression(any(DocumentReference.class), any(Collection.class),
+            any(NotificationPreference.class)))
+                .thenReturn(value(EventProperty.PAGE).eq(value("someValue1")).and(value("1").eq(value("1"))));
+
+        when(notificationFilter2.filterExpression(any(DocumentReference.class), any(Collection.class),
+            any(NotificationPreference.class)))
+                .thenReturn(value(EventProperty.TYPE).eq(value("someValue2")).and(value("2").eq(value("2"))));
+
+        when(notificationFilter1.matchesPreference(any(NotificationPreference.class))).thenReturn(true);
+        when(notificationFilter2.matchesPreference(any(NotificationPreference.class))).thenReturn(true);
+        when(notificationFilterManager.getFiltersRelatedToNotificationPreference(anyCollection(),
+
+=====================================================================
+Found a 17 line (185 tokens) duplication in the following files: 
+Starting at line 542 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 571 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+    void cleanupAccessToPasswordFields() throws Exception
+    {
+        // Initialize an XClass with a password field.
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "MyClass");
+        XWikiDocument xwikiDocument = this.xwiki.getDocument(documentReference, this.context);
+        BaseClass xClass = xwikiDocument.getXClass();
+        xClass.addPasswordField("password", "Password", 30);
+        this.xwiki.saveDocument(xwikiDocument, this.context);
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(0L);
+        when(this.query.execute()).thenReturn(Collections.emptyList());
+
+        this.request.put("classname", "XWiki.MyClass");
+
+=====================================================================
+Found a 21 line (183 tokens) duplication in the following files: 
+Starting at line 393 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 512 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery(queryString, Query.HQL)).thenReturn(query);
+        when(query.bindValue("owner", owner)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter1 = new DefaultQueryParameter(null);
+        queryParameter1.literal("foo").anyChars();
+        when(query.bindValue("constraint_0", queryParameter1)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter2 = new DefaultQueryParameter(null);
+        queryParameter2.anyChars().literal("bar").anyChars();
+        when(query.bindValue("constraint_1", queryParameter2)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter3 = new DefaultQueryParameter(null);
+        queryParameter3.literal("buz");
+        when(query.bindValue("constraint_2", queryParameter3)).thenReturn(query);
+
+        when(query.bindValue("filterType", NotificationFilterType.INCLUSIVE)).thenReturn(query);
+
+        when(query.setWiki(wikiName)).thenReturn(query);
+
+        when(query.execute()).thenReturn(List.of(3L));
+
+=====================================================================
+Found a 20 line (183 tokens) duplication in the following files: 
+Starting at line 512 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 636 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery(queryString, Query.HQL)).thenReturn(query);
+        when(query.bindValue("owner", owner)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter1 = new DefaultQueryParameter(null);
+        queryParameter1.literal("foo").anyChars();
+        when(query.bindValue("constraint_0", queryParameter1)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter2 = new DefaultQueryParameter(null);
+        queryParameter2.anyChars().literal("bar").anyChars();
+        when(query.bindValue("constraint_1", queryParameter2)).thenReturn(query);
+
+        DefaultQueryParameter queryParameter3 = new DefaultQueryParameter(null);
+        queryParameter3.literal("buz");
+        when(query.bindValue("constraint_2", queryParameter3)).thenReturn(query);
+
+        when(query.bindValue("filterType", NotificationFilterType.INCLUSIVE)).thenReturn(query);
+
+        when(query.setWiki(wikiName)).thenReturn(query);
+        when(query.setOffset(offset.intValue())).thenReturn(query);
+
+=====================================================================
+Found a 29 line (182 tokens) duplication in the following files: 
+Starting at line 305 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-viewer/src/test/java/org/xwiki/office/viewer/internal/DefaultOfficeResourceViewerTest.java
+Starting at line 358 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-viewer/src/test/java/org/xwiki/office/viewer/internal/DefaultOfficeResourceViewerTest.java
+
+        when(attachmentCache.get(CACHE_KEY)).thenReturn(null);
+        when(documentAccessBridge.getAttachmentReferences(ATTACHMENT_REFERENCE.getDocumentReference())).thenReturn(
+            Collections.emptyList());
+        when(documentAccessBridge.getAttachmentVersion(ATTACHMENT_REFERENCE)).thenReturn(null);
+        XWikiAttachment attachment = mock(XWikiAttachment.class);
+        when(temporaryAttachmentSessionsManager.getUploadedAttachment(ATTACHMENT_REFERENCE))
+            .thenReturn(Optional.of(attachment));
+
+        ByteArrayInputStream attachmentContent = new ByteArrayInputStream(new byte[256]);
+        when(attachment.getContentInputStream(this.context)).thenReturn(attachmentContent);
+
+        XDOMOfficeDocument xdomOfficeDocument =
+            new XDOMOfficeDocument(new XDOM(new ArrayList<Block>()), Collections.emptyMap(), componentManager, null);
+        when(
+            officeDocumentBuilder.build(attachmentContent, ATTACHMENT_REFERENCE.getName(),
+                ATTACHMENT_REFERENCE.getDocumentReference(), false)).thenReturn(xdomOfficeDocument);
+
+        this.officeResourceViewer.createView(ATTACHMENT_RESOURCE_REFERENCE, DEFAULT_VIEW_PARAMETERS);
+
+        verify(attachmentCache).set(eq(CACHE_KEY), any(AttachmentOfficeDocumentView.class));
+    }
+
+    /**
+     * Tests creating a view for an office attachment which has already been viewed and cached.
+     * 
+     * @throws Exception if an error occurs.
+     */
+    @Test
+    void viewExistingOfficeAttachmentWithCacheHit() throws Exception
+
+=====================================================================
+Found a 12 line (181 tokens) duplication in the following files: 
+Starting at line 152 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/user/api/XWikiUserTest.java
+Starting at line 166 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/user/api/XWikiUserTest.java
+
+        XWikiUser user = new XWikiUser((DocumentReference) null);
+        user.setDisabled(true, this.mockitoOldcore.getXWikiContext());
+        verify(this.userDocument, never())
+            .setIntValue(same(this.userClassReference), any(String.class), any(Integer.class));
+        verify(this.mockitoOldcore.getSpyXWiki(), never())
+            .saveDocument(any(XWikiDocument.class), any(String.class), same(this.mockitoOldcore.getXWikiContext()));
+
+        user.setDisabled(false, this.mockitoOldcore.getXWikiContext());
+        verify(this.userDocument, never())
+            .setIntValue(same(this.userClassReference), any(String.class), any(Integer.class));
+        verify(this.mockitoOldcore.getSpyXWiki(), never())
+            .saveDocument(any(XWikiDocument.class), any(String.class), same(this.mockitoOldcore.getXWikiContext()));
+
+=====================================================================
+Found a 12 line (181 tokens) duplication in the following files: 
+Starting at line 221 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/user/api/XWikiUserTest.java
+Starting at line 235 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/user/api/XWikiUserTest.java
+
+        XWikiUser user = new XWikiUser((DocumentReference) null);
+        user.setEmailChecked(true, this.mockitoOldcore.getXWikiContext());
+        verify(this.userDocument, never())
+            .setIntValue(same(this.userClassReference), any(String.class), any(Integer.class));
+        verify(this.mockitoOldcore.getSpyXWiki(), never())
+            .saveDocument(any(XWikiDocument.class), any(String.class), same(this.mockitoOldcore.getXWikiContext()));
+
+        user.setEmailChecked(false, this.mockitoOldcore.getXWikiContext());
+        verify(this.userDocument, never())
+            .setIntValue(same(this.userClassReference), any(String.class), any(Integer.class));
+        verify(this.mockitoOldcore.getSpyXWiki(), never())
+            .saveDocument(any(XWikiDocument.class), any(String.class), same(this.mockitoOldcore.getXWikiContext()));
+
+=====================================================================
+Found a 103 line (180 tokens) duplication in the following files: 
+Starting at line 67 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/HttpServletRequestStub.java
+Starting at line 49 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletRequestStub.java
+
+{
+    /**
+     * Builder for {@link HttpServletRequestStub}.
+     * 
+     * @version $Id: a1d87bdd8047f5882fc810917583c2c210325f52 $
+     */
+    public static class Builder
+    {
+        private URL requestURL;
+
+        private String contextPath;
+
+        private Map<String, String[]> requestParameters;
+
+        private Map<String, List<String>> headers;
+
+        private Cookie[] cookies;
+
+        private String remoteAddr;
+
+        private HttpSession httpSession;
+
+        /**
+         * Default constructor.
+         */
+        public Builder()
+        {
+        }
+
+        /**
+         * @param requestURL the request URL
+         * @return this builder
+         */
+        public Builder setRequestURL(URL requestURL)
+        {
+            this.requestURL = requestURL;
+            return this;
+        }
+
+        /**
+         * @param contextPath the context path
+         * @return this builder
+         */
+        public Builder setContextPath(String contextPath)
+        {
+            this.contextPath = contextPath;
+            return this;
+        }
+
+        /**
+         * @param requestParameters the request parameters
+         * @return this builder
+         */
+        public Builder setRequestParameters(Map<String, String[]> requestParameters)
+        {
+            this.requestParameters = requestParameters;
+            return this;
+        }
+
+        /**
+         * @param headers the request headers
+         * @return this builder
+         */
+        public Builder setHeaders(Map<String, List<String>> headers)
+        {
+            this.headers = headers;
+            return this;
+        }
+
+        /**
+         * @param cookies the request cookies
+         * @return this builder
+         */
+        public Builder setCookies(Cookie[] cookies)
+        {
+            this.cookies = cookies;
+            return this;
+        }
+
+        /**
+         * @param remoteAddr the remote address
+         * @return this builder
+         */
+        public Builder setRemoteAddr(String remoteAddr)
+        {
+            this.remoteAddr = remoteAddr;
+            return this;
+        }
+
+        /**
+         * @param httpSession the http session to initialize the {@link HttpServletRequestStub} instance with
+         * @return the current builder
+         */
+        public Builder setHttpSession(HttpSession httpSession)
+        {
+            this.httpSession = httpSession;
+            return this;
+        }
+
+        /**
+         * @return the built {@link HttpServletRequestStub} instance
+         */
+        public HttpServletRequestStub build()
+
+=====================================================================
+Found a 23 line (178 tokens) duplication in the following files: 
+Starting at line 659 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 742 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+    void obfuscateEmails(boolean obfuscate, String expectedHql, Map<String, Object> expectedBindValues,
+        String expectedMail, String expectedMailValue) throws Exception
+    {
+        // TODO: We mock the mail configuration as it relies on document that are loaded through xar files from external
+        //  modules, which is currently not possible (would it be loaded using a mandatory document initializer, it 
+        //  would work though).
+        when(this.generalMailConfiguration.shouldObfuscate()).thenReturn(obfuscate);
+
+        DocumentReference myClassReference = new DocumentReference("xwiki", "Space", "MyClass");
+        XWikiDocument xClassDocument = new XWikiDocument(myClassReference);
+        xClassDocument.getXClass().addEmailField("mail", "Email", 100);
+        xClassDocument.getXClass().addTextField("name", "Name", 100);
+        this.xwiki.saveDocument(xClassDocument, this.context);
+
+        XWikiDocument xObjectDocument = new XWikiDocument(new DocumentReference("xwiki", "Space", "MyObject"));
+        xObjectDocument.setSyntax(XWIKI_2_1);
+        BaseObject baseObject = xObjectDocument.newXObject(myClassReference, this.context);
+        baseObject.set("mail", "test@mail.com", this.context);
+        baseObject.set("name", "testName", this.context);
+        this.xwiki.saveDocument(xObjectDocument, this.context);
+
+        setColumns("mail,name");
+        setClassName("Space.MyClass");
+
+=====================================================================
+Found a 14 line (177 tokens) duplication in the following files: 
+Starting at line 237 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+Starting at line 298 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+
+    void moveDocumentToRestrictedDestinationAuthor() throws Throwable
+    {
+        DocumentReference oldReference = new DocumentReference("wiki", "One", "Page");
+        DocumentReference newReference = new DocumentReference("wiki", "Two", "Page");
+        when(this.modelBridge.exists(oldReference)).thenReturn(true);
+
+        DocumentReference userReference = new DocumentReference("wiki", "Users", "Alice");
+        when(this.authorization.hasAccess(Right.DELETE, userReference, oldReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, userReference, newReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, userReference, oldReference)).thenReturn(true);
+
+        DocumentReference authorReference = new DocumentReference("wiki", "Users", "Bob");
+        when(this.authorization.hasAccess(Right.DELETE, authorReference, oldReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, newReference)).thenReturn(false);
+
+=====================================================================
+Found a 6 line (176 tokens) duplication in the following files: 
+Starting at line 381 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
+Starting at line 390 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
+
+        assertSame(status11, this.store.events.get(event1.getId()).statuses.get(status11.getEntityId()));
+        assertSame(status12, this.store.events.get(event1.getId()).statuses.get(status12.getEntityId()));
+        assertSame(status13, this.store.events.get(event1.getId()).statuses.get(status13.getEntityId()));
+        assertSame(status21, this.store.events.get(event2.getId()).statuses.get(status21.getEntityId()));
+        assertSame(status22, this.store.events.get(event2.getId()).statuses.get(status22.getEntityId()));
+        assertSame(status23, this.store.events.get(event2.getId()).statuses.get(status23.getEntityId()));
+
+=====================================================================
+Found a 19 line (176 tokens) duplication in the following files: 
+Starting at line 79 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 207 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        NotificationParameters parameters = new NotificationParameters();
+        parameters.user = USER_REFERENCE;
+        parameters.format = NotificationFormat.ALERT;
+        parameters.fromDate = this.startDate;
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_HIDDEN, true, CompareType.EQUALS, true), conditions.next());
+
+=====================================================================
+Found a 12 line (176 tokens) duplication in the following files: 
+Starting at line 176 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/DocumentSolrMetadataExtractorTest.java
+Starting at line 126 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/ObjectPropertySolrMetadataExtractorTest.java
+
+        when(wiki.getDocument(this.documentReference, this.xcontext)).thenReturn(this.document);
+        when(this.document.getDocumentReference()).thenReturn(this.documentReference);
+        when(this.document.isHidden()).thenReturn(false);
+        when(this.document.getLocale()).thenReturn(Locale.ROOT);
+        when(this.document.getRealLocale()).thenReturn(Locale.US);
+        when(this.document.getAuthors()).thenReturn(this.documentAuthors);
+
+        when(this.document.getTranslatedDocument(Locale.FRENCH, this.xcontext)).thenReturn(this.translatedDocument);
+        when(this.translatedDocument.getRealLocale()).thenReturn(Locale.FRENCH);
+        when(this.translatedDocument.getLocale()).thenReturn(Locale.FRENCH);
+        when(this.translatedDocument.getDocumentReference()).thenReturn(this.frenchDocumentReference);
+        when(this.translatedDocument.getAuthors()).thenReturn(this.documentAuthors);
+
+=====================================================================
+Found a 20 line (176 tokens) duplication in the following files: 
+Starting at line 381 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 454 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+
+    void checkVerificationCodeWrongCode() throws Exception
+    {
+        when(this.userReference.toString()).thenReturn("user:Foobar");
+        when(this.userManager.exists(this.userReference)).thenReturn(true);
+        InternetAddress email = new InternetAddress("foobar@xwiki.org");
+        when(this.userProperties.getEmail()).thenReturn(email);
+        String verificationCode = "abcd1245";
+        BaseObject xObject = mock(BaseObject.class);
+        when(this.userDocument
+            .getXObject(ResetPasswordRequestClassDocumentInitializer.REFERENCE))
+            .thenReturn(xObject);
+        String encodedVerificationCode = "encodedVerificationCode";
+        when(xObject.getStringValue(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD))
+            .thenReturn(encodedVerificationCode);
+        BaseClass baseClass = mock(BaseClass.class);
+        when(xObject.getXClass(context)).thenReturn(baseClass);
+        PasswordClass passwordClass = mock(PasswordClass.class);
+        when(baseClass.get(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD)).thenReturn(passwordClass);
+        when(passwordClass.getEquivalentPassword(encodedVerificationCode, verificationCode))
+            .thenReturn("anotherCode");
+
+=====================================================================
+Found a 90 line (175 tokens) duplication in the following files: 
+Starting at line 192 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/NotificationMailDefaultHtmlTest.java
+Starting at line 414 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/NotificationMailDefaultHtmlTest.java
+
+            + "              <strong>Event Test&#38;Type</strong>\n"
+            + "\n"
+            + "      </td>\n"
+            + "                        <td style=\"vertical-align: top;\">\n"
+            + "                  <div>\n"
+            // The hierarchy should go inside this div but it's not an easy one to mock.
+            + "    <div style=\"background-color: #f5f5f5; color: #707070; padding: 4px 8px; border-radius: 7px; "
+            + "font-size: 8px;\">\n"
+            + "      \n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "                                                                                                                                                                                                        xwiki / Hello &#38; Co / Hello &#38; Co\n"
+            + "      </div>\n"
+            + "                  <a style=\"color: #2f6faf; text-decoration: none;\" "
+            + "href=\"/xwiki/bin/view/Test/\">Hello &amp; Co</a>\n"
+            + "  </div>\n"
+            + "                        User information:                       "
+            + "<img src=\"cid:User.jpg\" alt=\"U\" width=\"16\" height=\"16\" style=\"vertical-align: middle;\"/>\n"
+            + "     <a style=\"color: #2f6faf; text-decoration: none;\" "
+            + "href=\"/xwiki/bin/view/XWiki/User\">First & Name</a>\n"
+            + "      \n"
+            + "      <div>\n"
+            + "    <small style=\"color: #767676; font-size: 0.8em;\">\n"
+            + "      A few minutes ago\n"
+            + "    </small>\n"
+            + "  </div>\n"
+            // No details as there's a single event
+            + "                              \n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "\n"
+            + "                                                            \n"
+
+=====================================================================
+Found a 20 line (174 tokens) duplication in the following files: 
+Starting at line 660 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeManagerTest.java
+Starting at line 691 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeManagerTest.java
+
+            XWikiAttachment attachment = new XWikiAttachment();
+
+            attachment.setContent(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+            attachment.setLongSize(10);
+            attachment.setFilename("file");
+
+            this.previousDocument.addAttachment(attachment);
+
+            attachment = attachment.clone();
+            attachment.setContent(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 });
+            attachment.setLongSize(9);
+
+            this.nextDocument.addAttachment(attachment);
+
+            MergeDocumentResult result = this.mergeManager.mergeDocument(this.previousDocument, this.nextDocument,
+                this.currentDocument, this.configuration);
+            List<LogEvent> logs = result.getLog().getLogs(LogLevel.ERROR);
+            assertEquals(1, logs.size());
+            assertEquals("Collision found on attachment [Attachment wiki:space.page@file]",
+                logs.get(0).getFormattedMessage());
+
+=====================================================================
+Found a 11 line (173 tokens) duplication in the following files: 
+Starting at line 146 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+Starting at line 190 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+
+        when(this.oldcore.getMockContextualAuthorizationManager().hasAccess(Right.PROGRAM)).thenReturn(true);
+
+        when(this.xWiki.getVersioningStore()).thenReturn(mockXWikiVersioningStore);
+        when(this.xWiki.getStore()).thenReturn(xWikiStoreInterface);
+        when(this.xWiki.getDocument(any(DocumentReference.class), any())).thenReturn(this.document);
+        when(this.xWiki.getDocumentReference(any(XWikiRequest.class), any())).thenReturn(documentReference);
+        when(this.xWiki.getDocumentReference(any(EntityReference.class), any()))
+            .then(i -> new DocumentReference(i.getArgument(0)));
+        when(this.xWiki.getLanguagePreference(any())).thenReturn("en");
+        when(this.xWiki.getSectionEditingDepth()).thenReturn(2L);
+        when(this.xWiki.getRightService()).thenReturn(this.oldcore.getMockRightService());
+
+=====================================================================
+Found a 18 line (173 tokens) duplication in the following files: 
+Starting at line 235 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 264 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+    public void testVerifyMultipleObjectsMultipleXWikiClassChanged() throws XWikiException
+    {
+        XWikiDocument newDoc = this.classDoc.clone();
+        XWikiDocument oldDoc = this.classDoc.clone();
+
+        BaseObject otherOldObject = oldDoc.newObject(this.otherClassName, this.context);
+        BaseObject oldObj = oldDoc.newObject(this.testClassName, this.context);
+        BaseObject oldObj2 = oldDoc.newObject(this.testClassName, this.context);
+        BaseObject otherNewObject = newDoc.newObject(this.otherClassName, this.context);
+        BaseObject newObj = newDoc.newObject(this.testClassName, this.context);
+        BaseObject newObj2 = newDoc.newObject(this.testClassName, this.context);
+
+        otherOldObject.setStringValue(this.testPropertyName, "value1");
+        oldObj.setStringValue(this.testPropertyName, "value1");
+        oldObj2.setStringValue(this.testPropertyName, "value2");
+        otherNewObject.setStringValue(this.testPropertyName, "value1");
+        newObj.setStringValue(this.testPropertyName, "value1");
+        newObj2.setStringValue(this.testPropertyName, "value3");
+
+=====================================================================
+Found a 36 line (173 tokens) duplication in the following files: 
+Starting at line 69 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/selector/ExhaustiveCheckTagsSelectorTest.java
+Starting at line 65 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/selector/UnsafeTagsSelectorTest.java
+
+    private ExhaustiveCheckTagsSelector tagsSelector;
+
+    @MockComponent
+    protected Provider<XWikiContext> contextProvider;
+
+    @MockComponent
+    protected ContextualAuthorizationManager contextualAuthorizationManager;
+
+    @MockComponent
+    @Named("current")
+    protected DocumentReferenceResolver<String> stringDocumentReferenceResolver;
+
+    @Mock
+    private XWikiContext context;
+
+    @Mock
+    private XWiki wiki;
+
+    @Mock
+    private XWikiStoreInterface store;
+
+    @Mock
+    private QueryManager queryManager;
+
+    @Mock
+    private Query query;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        when(this.contextProvider.get()).thenReturn(this.context);
+        when(this.context.getWiki()).thenReturn(this.wiki);
+        when(this.wiki.getStore()).thenReturn(this.store);
+        when(this.store.getQueryManager()).thenReturn(this.queryManager);
+        when(this.queryManager.createQuery(anyString(), anyString())).thenReturn(this.query);
+        when(this.query.addFilter(any())).thenReturn(this.query);
+
+=====================================================================
+Found a 19 line (172 tokens) duplication in the following files: 
+Starting at line 420 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 456 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+
+        when(this.userReference.toString()).thenReturn("user:Foobar");
+        when(this.userManager.exists(this.userReference)).thenReturn(true);
+        InternetAddress email = new InternetAddress("foobar@xwiki.org");
+        when(this.userProperties.getEmail()).thenReturn(email);
+        String verificationCode = "abcd1245";
+        BaseObject xObject = mock(BaseObject.class);
+        when(this.userDocument
+            .getXObject(ResetPasswordRequestClassDocumentInitializer.REFERENCE))
+            .thenReturn(xObject);
+        String encodedVerificationCode = "encodedVerificationCode";
+        when(xObject.getStringValue(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD))
+            .thenReturn(encodedVerificationCode);
+        BaseClass baseClass = mock(BaseClass.class);
+        when(xObject.getXClass(context)).thenReturn(baseClass);
+        PasswordClass passwordClass = mock(PasswordClass.class);
+        when(baseClass.get(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD)).thenReturn(passwordClass);
+        when(passwordClass.getEquivalentPassword(encodedVerificationCode, verificationCode))
+            .thenReturn("anotherCode");
+        String exceptionMessage = "Wrong verification code";
+
+=====================================================================
+Found a 31 line (171 tokens) duplication in the following files: 
+Starting at line 210 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+Starting at line 259 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+
+        this.pack.install(this.oldcore.getXWikiContext());
+
+        // check if it is there
+        XWikiDocument foundDocument = this.xwiki.getDocument(
+            new LocalDocumentReference("Test", "\u60A8\u597D\u4E16\u754C"), this.oldcore.getXWikiContext());
+        assertFalse(foundDocument.isNew());
+
+        XWikiDocument nonExistingDocument = this.xwiki
+            .getDocument(new LocalDocumentReference("Test", "DocImportNonexisting"), this.oldcore.getXWikiContext());
+        assertTrue(nonExistingDocument.isNew());
+
+        XWikiDocument foundTranslationDocument =
+            foundDocument.getTranslatedDocument("fr", this.oldcore.getXWikiContext());
+        assertSame(foundDocument, foundTranslationDocument);
+
+        XWikiDocument doc1Translation = new XWikiDocument(
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Test", "\u60A8\u597D\u4E16\u754C"));
+        doc1Translation.setLanguage("fr");
+        doc1Translation.setDefaultLanguage("zh");
+        this.xwiki.saveDocument(doc1Translation, this.oldcore.getXWikiContext());
+        foundTranslationDocument = foundDocument.getTranslatedDocument("fr", this.oldcore.getXWikiContext());
+        assertNotSame(foundDocument, foundTranslationDocument);
+    }
+
+    /**
+     * Test the regular document import with non-ascii document title and non-utf8 platform encoding.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testImportDocumentNonAsciiTitleNonUtf8PlatformEncoding() throws Exception
+
+=====================================================================
+Found a 18 line (171 tokens) duplication in the following files: 
+Starting at line 383 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 420 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+
+        when(this.userReference.toString()).thenReturn("user:Foobar");
+        when(this.userManager.exists(this.userReference)).thenReturn(true);
+        InternetAddress email = new InternetAddress("foobar@xwiki.org");
+        when(this.userProperties.getEmail()).thenReturn(email);
+        String verificationCode = "abcd1245";
+        BaseObject xObject = mock(BaseObject.class);
+        when(this.userDocument
+            .getXObject(ResetPasswordRequestClassDocumentInitializer.REFERENCE))
+            .thenReturn(xObject);
+        String encodedVerificationCode = "encodedVerificationCode";
+        when(xObject.getStringValue(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD))
+            .thenReturn(encodedVerificationCode);
+        BaseClass baseClass = mock(BaseClass.class);
+        when(xObject.getXClass(context)).thenReturn(baseClass);
+        PasswordClass passwordClass = mock(PasswordClass.class);
+        when(baseClass.get(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD)).thenReturn(passwordClass);
+        when(passwordClass.getEquivalentPassword(encodedVerificationCode, verificationCode))
+            .thenReturn("anotherCode");
+
+=====================================================================
+Found a 73 line (170 tokens) duplication in the following files: 
+Starting at line 68 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-storage/src/main/java/org/xwiki/mail/script/DeprecatedMailStorageScriptService.java
+Starting at line 66 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/script/MailStorageScriptService.java
+
+    @Inject
+    @Named("filesystem")
+    private MailContentStore mailContentStore;
+
+    @Inject
+    @Named("database")
+    private MailStatusStore mailStatusStore;
+
+    @Inject
+    private Provider<XWikiContext> xwikiContextProvider;
+
+    @Inject
+    private ContextualAuthorizationManager authorizationManager;
+
+    @Inject
+    private MailStorageConfiguration storageConfiguration;
+
+    @Inject
+    @Named("database")
+    private MailResender mailResender;
+
+    /**
+     * Resend the serialized MimeMessage synchronously.
+     *
+     * @param batchId the name of the directory that contains serialized MimeMessage
+     * @param uniqueMessageId the unique id of the serialized MimeMessage
+     * @return the result and status of the send batch; null if an error occurred when getting the message from the
+     *         store
+     */
+    public ScriptMailResult resend(String batchId, String uniqueMessageId)
+    {
+        ScriptMailResult result = resendAsynchronously(batchId, uniqueMessageId);
+        if (result != null) {
+            // Wait for the message to have been resent before returning
+            result.getStatusResult().waitTillProcessed(Long.MAX_VALUE);
+        }
+        return result;
+    }
+
+    /**
+     * Resend the serialized MimeMessage asynchronously.
+     *
+     * @param batchId the name of the directory that contains serialized MimeMessage
+     * @param uniqueMessageId the unique id of the serialized MimeMessage
+     * @return the result and status of the send batch; null if an error occurred when getting the message from the
+     *         store
+     * @since 9.3RC1
+     */
+    public ScriptMailResult resendAsynchronously(String batchId, String uniqueMessageId)
+    {
+        try {
+            MailStatusResult statusResult = this.mailResender.resendAsynchronously(batchId, uniqueMessageId);
+            ScriptMailResult scriptMailResult = new ScriptMailResult(new DefaultMailResult(batchId), statusResult);
+            return scriptMailResult;
+        } catch (MailStoreException e) {
+            // Save the exception for reporting through the script services's getLastError() API
+            setError(e);
+            return null;
+        }
+    }
+
+    /**
+     * Resends all mails matching the passed filter map.
+     *
+     * @param filterMap the map of Mail Status parameters to match (e.g. "state", "wiki", "batchId", etc)
+     * @param offset the number of rows to skip (0 means don't skip any row)
+     * @param count the number of rows to return. If 0 then all rows are returned
+     * @return the mail results for the resent mails and null if an error occurred while loading the mail statuses
+     *         from the store
+     * @since 9.3RC1
+     */
+    public List<ScriptMailResult> resendAsynchronously(Map<String, Object> filterMap, int offset, int count)
+    {
+
+=====================================================================
+Found a 25 line (170 tokens) duplication in the following files: 
+Starting at line 188 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
+Starting at line 366 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
+
+        when(this.notificationFilterManager.getAllFilters(wikiReference)).thenReturn(List.of(
+            // They are shuffled to test ordering
+            filter3,
+            filter4,
+            filter6,
+            filter2,
+            filter5,
+            filter1,
+            filter7
+        ));
+
+        when(filter2.getFormats()).thenReturn(List.of(NotificationFormat.ALERT, NotificationFormat.EMAIL));
+        when(filter4.getFormats()).thenReturn(List.of());
+        when(filter5.getFormats()).thenReturn(List.of(NotificationFormat.ALERT));
+        when(filter6.getFormats()).thenReturn(List.of(NotificationFormat.EMAIL));
+        when(filter7.getFormats()).thenReturn(List.of(NotificationFormat.EMAIL, NotificationFormat.ALERT));
+
+        // There's explicitely no activation data for filter2 and filter6
+        ToggleableNotificationFilterActivation activationFilter4 = mock(ToggleableNotificationFilterActivation.class,
+            filter4Name);
+        ToggleableNotificationFilterActivation activationFilter5 = mock(ToggleableNotificationFilterActivation.class,
+            filter5Name);
+        ToggleableNotificationFilterActivation activationFilter7 = mock(ToggleableNotificationFilterActivation.class,
+            filter7Name);
+        when(this.filterPreferencesModelBridge.getToggleableFilterActivations(prefReference)).thenReturn(Map.of(
+
+=====================================================================
+Found a 22 line (170 tokens) duplication in the following files: 
+Starting at line 87 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/DefaultRatingsManagerFactoryTest.java
+Starting at line 113 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/DefaultRatingsManagerFactoryTest.java
+
+        when(this.contextComponentManager.getInstance(RatingsConfiguration.class, hint))
+            .thenReturn(this.ratingsConfiguration);
+        when(this.ratingsConfiguration.getRatingsStorageHint()).thenReturn("someStorage");
+        when(this.contextComponentManager.getInstance(RatingsManager.class, "someStorage"))
+            .thenReturn(this.ratingsManager);
+        ComponentDescriptor componentDescriptor = mock(ComponentDescriptor.class);
+        when(componentDescriptor.getImplementation()).thenReturn(SolrRatingsManager.class);
+        when(this.contextComponentManager.getComponentDescriptor(RatingsManager.class, "someStorage"))
+            .thenReturn(componentDescriptor);
+        DefaultComponentDescriptor<RatingsManager> expectedComponentDescriptor = new DefaultComponentDescriptor<>();
+        expectedComponentDescriptor.setImplementation(SolrRatingsManager.class);
+        expectedComponentDescriptor.setRoleHint(hint);
+        expectedComponentDescriptor.setInstantiationStrategy(ComponentInstantiationStrategy.SINGLETON);
+        expectedComponentDescriptor.setRoleHintPriority(0);
+        expectedComponentDescriptor.setRoleTypePriority(0);
+
+        assertSame(this.ratingsManager, this.factory.getRatingsManager(hint));
+        verify(this.currentComponentManager).registerComponent(expectedComponentDescriptor, this.ratingsManager);
+    }
+
+    @Test
+    void getNewInstanceDefaultConfiguration() throws Exception
+
+=====================================================================
+Found a 26 line (169 tokens) duplication in the following files: 
+Starting at line 93 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/test/java/org/xwiki/rendering/internal/macro/wikibridge/DefaultWikiMacroManagerTest.java
+Starting at line 251 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/test/java/org/xwiki/rendering/internal/macro/wikibridge/DefaultWikiMacroManagerTest.java
+
+    void registerAndUnregisterWikiMacroWhenGlobalVisibilityAndAllowed() throws Exception
+    {
+        WikiMacro wikiMacro = generateWikiMacro(WikiMacroVisibility.GLOBAL);
+
+        // Simulate a user who's allowed for the GLOBAL visibility
+        when(this.wikiMacroFactory.isAllowed(wikiMacro.getDocumentReference(), WikiMacroVisibility.GLOBAL))
+            .thenReturn(true);
+
+        assertFalse(this.wikiMacroManager.hasWikiMacro(wikiMacro.getDocumentReference()));
+
+        when(this.serializer.serialize(this.authorReference)).thenReturn("authorwiki:authorspace.authorpage");
+
+        // Indicate current wiki is the main one (otherwise it won't be registered at root level)
+        when(this.wikiDescriptorManager.isMainWiki(wikiMacro.getDocumentReference().getWikiReference().getName()))
+            .thenReturn(true);
+
+        // Test registration
+        this.wikiMacroManager.registerWikiMacro(wikiMacro.getDocumentReference(), wikiMacro);
+        assertTrue(this.wikiMacroManager.hasWikiMacro(wikiMacro.getDocumentReference()));
+
+        // Verify that the WikiMacroManager has registered the macro against the root CM
+        assertTrue(this.componentManager.hasComponent(Macro.class, "testwikimacro"));
+
+        // Verify that the user and wiki where the macro is located have been set in the context
+        verify(this.bridge).setCurrentUser("authorwiki:authorspace.authorpage");
+        verify(this.modelContext).setCurrentEntityReference(wikiMacro.getDocumentReference());
+
+=====================================================================
+Found a 21 line (165 tokens) duplication in the following files: 
+Starting at line 233 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/LiveDataRendererConfiguration.java
+Starting at line 46 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/URLQueryStringParser.java
+
+    private Map<String, List<String>> getURLParameters(String url) throws Exception
+    {
+        URL baseURL = new URL("http://www.xwiki.org");
+        String queryString = new URL(baseURL, url).getQuery();
+        Map<String, List<String>> parameters = new HashMap<>();
+        for (String entry : queryString.split("&")) {
+            String[] parts = entry.split("=", 2);
+            String key = URLDecoder.decode(parts[0], UTF8);
+            if (key.isEmpty()) {
+                continue;
+            }
+            String value = parts.length == 2 ? URLDecoder.decode(parts[1], UTF8) : "";
+            List<String> values = parameters.get(key);
+            if (values == null) {
+                values = new ArrayList<>();
+                parameters.put(key, values);
+            }
+            values.add(value);
+        }
+        return parameters;
+    }
+
+=====================================================================
+Found a 24 line (164 tokens) duplication in the following files: 
+Starting at line 304 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+Starting at line 452 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+
+        importFromXML("documentwithunexistingobjectproperty", outputProperties);
+
+        XWikiDocument document = this.oldcore.getSpyXWiki().getDocument(new DocumentReference("wiki", "space", "page"),
+            this.oldcore.getXWikiContext());
+
+        assertFalse(document.isNew());
+
+        // Objects
+
+        Map<DocumentReference, List<BaseObject>> objects = document.getXObjects();
+        assertEquals(1, objects.size());
+
+        List<BaseObject> documentObjects = objects.get(new DocumentReference("wiki", "space", "page"));
+        assertEquals(1, documentObjects.size());
+        BaseObject documentObject = documentObjects.get(0);
+        assertEquals(0, documentObject.getNumber());
+        assertEquals(new DocumentReference("wiki", "space", "page"), documentObject.getXClassReference());
+
+        assertEquals(1, documentObject.getFieldList().size());
+        assertEquals(1, documentObject.getIntValue("prop1"));
+    }
+
+    @Test
+    void documentwithnumberversion() throws FilterException, XWikiException
+
+=====================================================================
+Found a 15 line (164 tokens) duplication in the following files: 
+Starting at line 82 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/spaces/SpaceAttachmentsResourceImplTest.java
+Starting at line 80 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/wikis/WikiAttachmentsResourceImplTest.java
+
+        when(query.setLimit(5)).thenReturn(query);
+
+        XWikiAttachment xwikiAttachment = mock(XWikiAttachment.class);
+        AttachmentReference xwikiAttachmentReference = mock(AttachmentReference.class, "image");
+        when(xwikiAttachment.getReference()).thenReturn(xwikiAttachmentReference);
+        when(this.authorization.hasAccess(Right.VIEW, xwikiAttachmentReference)).thenReturn(true);
+
+        XWikiAttachment forbiddenAttachment = mock(XWikiAttachment.class);
+        AttachmentReference forbiddenAttachmentReference = mock(AttachmentReference.class, "forbidden");
+        when(forbiddenAttachment.getReference()).thenReturn(forbiddenAttachmentReference);
+        when(this.authorization.hasAccess(Right.VIEW, forbiddenAttachmentReference)).thenReturn(false);
+
+        List<Object> results = Arrays.asList(new Object[] {"Path.To", "Page", "1.3", xwikiAttachment},
+            new Object[] {"Path.To", "ForbiddenPage", "1.3", forbiddenAttachment});
+        when(query.execute()).thenReturn(results);
+
+=====================================================================
+Found a 22 line (163 tokens) duplication in the following files: 
+Starting at line 1173 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+Starting at line 1263 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+
+        assertTrue(objectEntityDiff.isDiffObfuscated("mypass"));
+        stringTestDiff = objectEntityDiff.getDiff("stringTest");
+        assertEquals(2, stringTestDiff.size());
+        assertEquals("@@ -1,0 +1,1 @@", stringTestDiff.get(0));
+        assertEquals("+anothervalue", stringTestDiff.get(1));
+
+        // diff 1.1 -> 3.1
+        changesPane.clickPreviousToVersion();
+        changesPane = new ChangesPane();
+        rawChanges = changesPane.getRawChanges();
+        contentDiff = rawChanges.getEntityDiff("Page properties").getDiff("Content");
+        assertEquals(3, contentDiff.size());
+        assertEquals("@@ -1,1 +1,1 @@", contentDiff.get(0));
+        assertEquals("-Some content", contentDiff.get(1));
+        assertEquals("+Some content<ins> 2</ins>", contentDiff.get(2));
+
+        objectEntityDiff = rawChanges.getEntityDiff(objectIdInDiff);
+        assertTrue(objectEntityDiff.isDiffObfuscated("mypass"));
+        stringTestDiff = objectEntityDiff.getDiff("stringTest");
+        assertEquals(2, stringTestDiff.size());
+        assertEquals("@@ -1,0 +1,1 @@", stringTestDiff.get(0));
+        assertEquals("+myvalue", stringTestDiff.get(1));
+
+=====================================================================
+Found a 23 line (163 tokens) duplication in the following files: 
+Starting at line 258 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImplTest.java
+Starting at line 280 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImplTest.java
+
+        preferencesObject.setStringValue("groups", this.group.getPrefixedFullName());
+
+        this.context.setWikiId(this.user.getWikiName());
+
+        assertTrue(this.rightService.hasAccessLevel("view", this.user.getPrefixedFullName(), doc.getPrefixedFullName(),
+            true, this.context),
+            "User group from another wiki does not have right on a local wiki when tested from user wiki");
+        assertTrue(this.rightService.hasAccessLevel("view", this.user.getFullName(), doc.getPrefixedFullName(), true,
+            this.context),
+            "User group from another wiki does not have right on a local wiki when tested from user wiki");
+
+        this.context.setWikiId(doc.getWikiName());
+
+        assertTrue(this.rightService.hasAccessLevel("view", this.user.getPrefixedFullName(), doc.getPrefixedFullName(),
+            true, this.context),
+            "User group from another wiki does not have right on a local wiki when tested from local wiki");
+        assertTrue(this.rightService.hasAccessLevel("view", this.user.getPrefixedFullName(), doc.getFullName(), true,
+            this.context),
+            "User group from another wiki does not have right on a local wiki when tested from local wiki");
+
+        // group from document's wiki
+
+        preferencesObject.setStringValue("groups", this.group2.getFullName());
+
+=====================================================================
+Found a 25 line (163 tokens) duplication in the following files: 
+Starting at line 100 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/legacy/doc/internal/ListAttachmentArchiveTest.java
+Starting at line 190 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/legacy/doc/internal/ListAttachmentArchiveTest.java
+
+    public void getArchiveAsString(MockitoComponentManager componentManager, @XWikiTempDir File tmpDir) throws Exception
+    {
+        Utils.setComponentManager(componentManager);
+        ServletEnvironment servletEnvironment = componentManager.getInstance(Environment.class);
+
+        ServletContext servletContextMock = mock(ServletContext.class);
+        servletEnvironment.setServletContext(servletContextMock);
+
+        when(servletContextMock.getAttribute("javax.servlet.context.tempdir")).thenReturn(tmpDir);
+
+        File temporaryDirectory = new File(tmpDir, "temporary");
+        File permanentDirectory = new File(tmpDir, "permanent-dir");
+
+        servletEnvironment.setTemporaryDirectory(temporaryDirectory);
+        servletEnvironment.setPermanentDirectory(permanentDirectory);
+
+        XWikiContext xWikiContext = new XWikiContext();
+        xWikiContext.setWiki(new XWiki());
+        XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
+
+        XWikiAttachment attachment11 = new XWikiAttachment(document, "file1");
+        attachment11.setVersion("8.1");
+        attachment11.setContent(IOUtils.toInputStream("First version", "UTF-8"));
+        attachment11.setMimeType("plain/text");
+        attachment11.setCharset("UTF-8");
+
+=====================================================================
+Found a 13 line (160 tokens) duplication in the following files: 
+Starting at line 414 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/SimpleEventQueryTest.java
+Starting at line 447 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/SimpleEventQueryTest.java
+
+        assertEquals(2, query.getConditions().size());
+        assertEquals(new CompareQueryCondition("property1", "value1", CompareType.EQUALS),
+            query.getConditions().get(0));
+        group1 = (GroupQueryCondition) query.getConditions().get(1);
+        assertTrue(group1.isOr());
+        assertEquals(2, group1.getConditions().size());
+        assertEquals(new CompareQueryCondition("property2", "value2", CompareType.EQUALS),
+            group1.getConditions().get(0));
+        group2 = (GroupQueryCondition) group1.getConditions().get(1);
+        assertFalse(group2.isOr());
+        assertEquals(2, group2.getConditions().size());
+        assertEquals(new CompareQueryCondition("property3", "value3", CompareType.EQUALS),
+            group2.getConditions().get(0));
+
+=====================================================================
+Found a 22 line (160 tokens) duplication in the following files: 
+Starting at line 148 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/test/java/org/xwiki/mail/script/MailStorageScriptServiceTest.java
+Starting at line 183 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/test/java/org/xwiki/mail/script/MailStorageScriptServiceTest.java
+
+        Map filterMap = Collections.singletonMap("state", "prepare_%");
+
+        MailStatus status1 = new MailStatus();
+        status1.setBatchId("batch1");
+        status1.setMessageId("message1");
+
+        MailStatus status2 = new MailStatus();
+        status2.setBatchId("batch2");
+        status2.setMessageId("message2");
+
+        MailStatusResult statusResult1 = mock(MailStatusResult.class, "status1");
+        when(statusResult1.getTotalMailCount()).thenReturn(1L);
+
+        MailStatusResult statusResult2 = mock(MailStatusResult.class, "status2");
+        when(statusResult2.getTotalMailCount()).thenReturn(2L);
+
+        List<Pair<MailStatus, MailStatusResult>> results = new ArrayList<>();
+        results.add(new ImmutablePair<>(status1, statusResult1));
+        results.add(new ImmutablePair<>(status2, statusResult2));
+
+        MailResender resender = this.componentManager.getInstance(MailResender.class, "database");
+        when(resender.resendAsynchronously(filterMap, 5, 10)).thenReturn(results);
+
+=====================================================================
+Found a 20 line (159 tokens) duplication in the following files: 
+Starting at line 173 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/template/DefaultMailTemplateManagerTest.java
+Starting at line 203 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/template/DefaultMailTemplateManagerTest.java
+
+        when(documentBridge.getProperty(any(DocumentReference.class), any(), eq(1), eq("html")))
+            .thenReturn("Salut <b>${name}</b> <br />${email}");
+
+        VelocityEngine velocityEngine = mock(VelocityEngine.class);
+        VelocityManager velocityManager = this.componentManager.getInstance(VelocityManager.class);
+        when(velocityManager.getVelocityEngine()).thenReturn(velocityEngine);
+        when(this.velocityEvaluator.evaluateVelocity(eq("Salut <b>${name}</b> <br />${email}"), any(),
+            any())).thenReturn("Salut <b>John Doe</b> <br />john@doe.com");
+
+        String result = this.templateManager.evaluate(documentReference, "html", Collections.emptyMap(),
+            Locale.FRENCH);
+
+        verify(documentBridge).getObjectNumber(any(), any(), eq("language"), eq("fr"));
+        verify(documentBridge).getObjectNumber(any(), any(), eq("language"), eq("en"));
+
+        assertEquals("Salut <b>John Doe</b> <br />john@doe.com", result);
+    }
+
+    @Test
+    public void evaluateWithObjectNotFoundWithDefaultLanguage() throws Exception
+
+=====================================================================
+Found a 18 line (159 tokens) duplication in the following files: 
+Starting at line 720 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 822 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void updateFromMacros(MockitoComponentManager componentManager) throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a terminal document to another terminal document.
+        DocumentReference oldLinkTarget = new DocumentReference("wiki", "A", "B");
+        DocumentReference newLinkTarget = new DocumentReference("wiki", "X", "Y");
+
+        XDOM xdom = mock(XDOM.class);
+        when(document.getXDOM()).thenReturn(xdom);
+
+        Map<String, String> includeParameters = new HashMap<String, String>();
+
+=====================================================================
+Found a 20 line (159 tokens) duplication in the following files: 
+Starting at line 52 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertiesAtPageVersionResourceImpl.java
+Starting at line 52 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertyAtPageVersionResourceImpl.java
+
+            String className, Integer objectNumber, Boolean withPrettyNames) throws XWikiRestException
+    {
+        try {
+            DocumentInfo documentInfo = getDocumentInfo(wikiName, spaceName, pageName, null, version, true, false);
+
+            Document doc = documentInfo.getDocument();
+
+            XWikiDocument xwikiDocument = Utils.getXWiki(componentManager)
+                    .getDocument(doc.getDocumentReference(), Utils.getXWikiContext(componentManager));
+
+            xwikiDocument = Utils.getXWiki(componentManager)
+                    .getDocument(xwikiDocument, doc.getVersion(), Utils.getXWikiContext(componentManager));
+
+            com.xpn.xwiki.objects.BaseObject baseObject = xwikiDocument.getObject(className, objectNumber);
+            if (baseObject == null) {
+                throw new WebApplicationException(Status.NOT_FOUND);
+            }
+
+            Object object = DomainObjectFactory.createObject(objectFactory, uriInfo.getBaseUri(), Utils.getXWikiContext(
+                    componentManager), doc, baseObject, true, Utils.getXWikiApi(componentManager), withPrettyNames);
+
+=====================================================================
+Found a 19 line (158 tokens) duplication in the following files: 
+Starting at line 307 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPluginTest.java
+Starting at line 201 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPluginTest.java
+
+            + "from the author.", this.logCapture.getMessage(0));
+
+        when(this.authorizationManager.hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference2,
+            documentReference2)).thenReturn(true);
+        this.skinExtensionPlugin.use(resource2, parameters2, context);
+
+        Set<String> expectedSet = new HashSet<>();
+        expectedSet.add(resource);
+        expectedSet.add(resource2);
+
+        resources = (Set<String>) context.get(className);
+        assertEquals(expectedSet, resources);
+
+        parametersMap =
+            (Map<String, Map<String, Object>>) context.get(className + "_parameters");
+        assertEquals(expectedParameters, parametersMap);
+        verify(this.authorizationManager, times(2))
+            .hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference2, documentReference2);
+        verify(this.skinExtensionAsync).use("ssx", resource2, null);
+
+=====================================================================
+Found a 20 line (157 tokens) duplication in the following files: 
+Starting at line 164 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-default/src/test/java/org/xwiki/icon/internal/DefaultIconThemesResourceTest.java
+Starting at line 206 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-default/src/test/java/org/xwiki/icon/internal/DefaultIconThemesResourceTest.java
+
+            .getIconsByTheme("wikiTest", "testTheme", asList("iconA", "unknownIcon", "iconB"));
+
+        ObjectFactory objectFactory = new ObjectFactory();
+        Icons expected = objectFactory.createIcons();
+        Icon iconA = objectFactory.createIcon();
+        iconA.setName("iconA");
+        iconA.setIconSetName("testTheme");
+        iconA.setIconSetType("TYPETEST");
+        iconA.setCssClass("testclass");
+        expected.getIcons().add(iconA);
+        Icon iconB = objectFactory.createIcon();
+        iconB.setName("iconB");
+        iconB.setIconSetName("testTheme");
+        iconB.setIconSetType("TYPETEST2");
+        iconB.setUrl("http://test/url");
+        expected.getIcons().add(iconB);
+        expected.getMissingIcons().add("unknownIcon");
+        assertEquals(marshal(expected), marshal(response));
+        verify(this.modelContext).setCurrentEntityReference(new WikiReference("wikiTest"));
+        verify(this.modelContext).setCurrentEntityReference(CURRENT_ENTITY);
+
+=====================================================================
+Found a 22 line (157 tokens) duplication in the following files: 
+Starting at line 136 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+Starting at line 177 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+Starting at line 221 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+
+        when(wikiDescriptorManager.getAllIds()).thenReturn(List.of("mainWiki"));
+
+        session = mock(Session.class);
+        when(hibernateStore.getSession(eq(xwikicontext))).thenReturn(session);
+        Query query = mock(Query.class);
+        when(session.createQuery(
+            "update DefaultNotificationFilterPreference p set p.page = :newPage " + "where p.page = :oldPage"))
+                .thenReturn(query);
+        when(query.setParameter(any(String.class), any())).thenReturn(query);
+        Query query2 = mock(Query.class);
+        when(session.createQuery(
+            "update DefaultNotificationFilterPreference p set p.pageOnly = :newPage " + "where p.pageOnly = :oldPage"))
+                .thenReturn(query2);
+        when(query2.setParameter(any(String.class), any())).thenReturn(query2);
+
+        // Test
+        DocumentRenamedEvent event = new DocumentRenamedEvent(source, target);
+        this.listener.onEvent(event, null, null);
+
+        // Verify
+        verify(cachedModelBridge).clearCache();
+        verify(query).setParameter("newPage", "xwiki:PageB");
+
+=====================================================================
+Found a 17 line (156 tokens) duplication in the following files: 
+Starting at line 271 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 298 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 329 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+
+        when(this.userManager.exists(this.userReference)).thenReturn(true);
+        InternetAddress email = new InternetAddress("foobar@xwiki.org");
+        when(this.userProperties.getEmail()).thenReturn(email);
+        String verificationCode = "abcd1245";
+        BaseObject xObject = mock(BaseObject.class);
+        when(this.userDocument
+            .getXObject(ResetPasswordRequestClassDocumentInitializer.REFERENCE))
+            .thenReturn(xObject);
+        String encodedVerificationCode = "encodedVerificationCode";
+        when(xObject.getStringValue(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD))
+            .thenReturn(encodedVerificationCode);
+        BaseClass baseClass = mock(BaseClass.class);
+        when(xObject.getXClass(context)).thenReturn(baseClass);
+        PasswordClass passwordClass = mock(PasswordClass.class);
+        when(baseClass.get(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD)).thenReturn(passwordClass);
+        when(passwordClass.getEquivalentPassword(encodedVerificationCode, verificationCode))
+            .thenReturn(encodedVerificationCode);
+
+=====================================================================
+Found a 18 line (155 tokens) duplication in the following files: 
+Starting at line 270 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 383 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 420 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 456 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+
+        when(this.configurationSource.getProperty(DefaultResetPasswordManager.TOKEN_LIFETIME, 60)).thenReturn(0);
+        when(this.userManager.exists(this.userReference)).thenReturn(true);
+        InternetAddress email = new InternetAddress("foobar@xwiki.org");
+        when(this.userProperties.getEmail()).thenReturn(email);
+        String verificationCode = "abcd1245";
+        BaseObject xObject = mock(BaseObject.class);
+        when(this.userDocument
+            .getXObject(ResetPasswordRequestClassDocumentInitializer.REFERENCE))
+            .thenReturn(xObject);
+        String encodedVerificationCode = "encodedVerificationCode";
+        when(xObject.getStringValue(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD))
+            .thenReturn(encodedVerificationCode);
+        BaseClass baseClass = mock(BaseClass.class);
+        when(xObject.getXClass(context)).thenReturn(baseClass);
+        PasswordClass passwordClass = mock(PasswordClass.class);
+        when(baseClass.get(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD)).thenReturn(passwordClass);
+        when(passwordClass.getEquivalentPassword(encodedVerificationCode, verificationCode))
+            .thenReturn(encodedVerificationCode);
+
+=====================================================================
+Found a 23 line (154 tokens) duplication in the following files: 
+Starting at line 107 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-storage/src/test/java/org/xwiki/mail/script/DeprecatedMailStorageScriptServiceTest.java
+Starting at line 146 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/test/java/org/xwiki/mail/script/MailStorageScriptServiceTest.java
+
+    public void resendAsynchronouslySeveralMessages() throws Exception
+    {
+        Map filterMap = Collections.singletonMap("state", "prepare_%");
+
+        MailStatus status1 = new MailStatus();
+        status1.setBatchId("batch1");
+        status1.setMessageId("message1");
+
+        MailStatus status2 = new MailStatus();
+        status2.setBatchId("batch2");
+        status2.setMessageId("message2");
+
+        MailStatusResult statusResult1 = mock(MailStatusResult.class, "status1");
+        when(statusResult1.getTotalMailCount()).thenReturn(1L);
+
+        MailStatusResult statusResult2 = mock(MailStatusResult.class, "status2");
+        when(statusResult2.getTotalMailCount()).thenReturn(2L);
+
+        List<Pair<MailStatus, MailStatusResult>> results = new ArrayList<>();
+        results.add(new ImmutablePair<>(status1, statusResult1));
+        results.add(new ImmutablePair<>(status2, statusResult2));
+
+        MailResender resender = this.mocker.getInstance(MailResender.class, "database");
+
+=====================================================================
+Found a 15 line (154 tokens) duplication in the following files: 
+Starting at line 43 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/PagesResourceIT.java
+Starting at line 60 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/SpacesResourceIT.java
+
+        GetMethod getMethod = executeGet(getFullUri(WikisResource.class));
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Wikis wikis = (Wikis) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+        Assert.assertTrue(wikis.getWikis().size() > 0);
+
+        Wiki wiki = wikis.getWikis().get(0);
+        Link link = getFirstLinkByRelation(wiki, Relations.SPACES);
+        Assert.assertNotNull(link);
+
+        getMethod = executeGet(link.getHref());
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Spaces spaces = (Spaces) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+        Assert.assertTrue(spaces.getSpaces().size() > 0);
+
+=====================================================================
+Found a 17 line (154 tokens) duplication in the following files: 
+Starting at line 298 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 384 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 421 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+Starting at line 457 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+
+        when(this.userManager.exists(this.userReference)).thenReturn(true);
+        InternetAddress email = new InternetAddress("foobar@xwiki.org");
+        when(this.userProperties.getEmail()).thenReturn(email);
+        String verificationCode = "abcd1245";
+        BaseObject xObject = mock(BaseObject.class);
+        when(this.userDocument
+            .getXObject(ResetPasswordRequestClassDocumentInitializer.REFERENCE))
+            .thenReturn(xObject);
+        String encodedVerificationCode = "encodedVerificationCode";
+        when(xObject.getStringValue(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD))
+            .thenReturn(encodedVerificationCode);
+        BaseClass baseClass = mock(BaseClass.class);
+        when(xObject.getXClass(context)).thenReturn(baseClass);
+        PasswordClass passwordClass = mock(PasswordClass.class);
+        when(baseClass.get(ResetPasswordRequestClassDocumentInitializer.VERIFICATION_FIELD)).thenReturn(passwordClass);
+        when(passwordClass.getEquivalentPassword(encodedVerificationCode, verificationCode))
+            .thenReturn(encodedVerificationCode);
+
+=====================================================================
+Found a 20 line (153 tokens) duplication in the following files: 
+Starting at line 109 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 206 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        when(this.userPropertiesResolver.resolve(any(UserReference.class))).thenReturn(userProperties);
+
+        NotificationParameters parameters = new NotificationParameters();
+        parameters.user = USER_REFERENCE;
+        parameters.format = NotificationFormat.ALERT;
+        parameters.fromDate = this.startDate;
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+
+=====================================================================
+Found a 18 line (152 tokens) duplication in the following files: 
+Starting at line 79 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 111 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        NotificationParameters parameters = new NotificationParameters();
+        parameters.user = USER_REFERENCE;
+        parameters.format = NotificationFormat.ALERT;
+        parameters.fromDate = this.startDate;
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+
+=====================================================================
+Found a 18 line (151 tokens) duplication in the following files: 
+Starting at line 131 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 486 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        when(ldQuery.getLimit()).thenReturn(limit);
+
+        LiveDataQuery.SortEntry sortEntry1 = mock(LiveDataQuery.SortEntry.class, "sortEntry1");
+        when(sortEntry1.isDescending()).thenReturn(false);
+        when(sortEntry1.getProperty()).thenReturn("scope");
+
+        LiveDataQuery.SortEntry sortEntry2 = mock(LiveDataQuery.SortEntry.class, "sortEntry2");
+        when(sortEntry2.isDescending()).thenReturn(true);
+        when(sortEntry2.getProperty()).thenReturn("isEnabled");
+
+        LiveDataQuery.SortEntry sortEntry3 = mock(LiveDataQuery.SortEntry.class, "sortEntry3");
+        when(sortEntry3.isDescending()).thenReturn(true);
+        when(sortEntry3.getProperty()).thenReturn("notificationFormats");
+
+        when(ldQuery.getSort()).thenReturn(List.of(sortEntry1, sortEntry2, sortEntry3));
+
+        String queryString = "select nfp from DefaultNotificationFilterPreference nfp where owner = :owner "
+            + "order by nfp.pageOnly asc, nfp.page asc, nfp.wiki asc, nfp.user asc, nfp.enabled desc, "
+
+=====================================================================
+Found a 14 line (151 tokens) duplication in the following files: 
+Starting at line 130 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/EditActionTest.java
+Starting at line 167 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/EditActionTest.java
+
+    void documentAuthorsWhenDocumentExist() throws XWikiException
+    {
+        XWikiDocument document = this.oldcore.getSpyXWiki().getDocument(new DocumentReference("wiki", "space", "page"),
+            this.oldcore.getXWikiContext());
+        document.getAuthors().setCreator(OTHERUSER_REFERENCE);
+        document.getAuthors().setContentAuthor(OTHERUSER_REFERENCE);
+        document.getAuthors().setEffectiveMetadataAuthor(OTHERUSER_REFERENCE);
+        document.getAuthors().setOriginalMetadataAuthor(OTHERUSER_REFERENCE);
+        this.oldcore.getSpyXWiki().saveDocument(document, this.oldcore.getXWikiContext());
+
+        document = this.oldcore.getSpyXWiki().getDocument(new DocumentReference("wiki", "space", "page"),
+            this.oldcore.getXWikiContext());
+        this.oldcore.getXWikiContext().setDoc(document);
+        this.oldcore.getXWikiContext().put("tdoc", document);
+
+=====================================================================
+Found a 10 line (150 tokens) duplication in the following files: 
+Starting at line 239 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-tests/src/test/it/org/xwiki/repository/test/ui/repository/RepositoryIT.java
+Starting at line 265 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-tests/src/test/it/org/xwiki/repository/test/ui/repository/RepositoryIT.java
+
+            getUtil().rest().getResource(Resources.EXTENSION_VERSION, null, this.baseExtension.getId().getId(), "1.0");
+
+        assertEquals(this.baseExtension.getId().getId(), extension.getId());
+        assertEquals(this.baseExtension.getType(), extension.getType());
+        assertEquals(this.baseExtension.getSummary(), extension.getSummary());
+        assertEquals(this.baseLicense.getName(), extension.getLicenses().get(0).getName());
+        assertEquals(this.baseExtension.getDescription(), extension.getDescription());
+        assertEquals(this.baseAuthor.getName(), extension.getAuthors().get(0).getName());
+        assertEquals(this.baseAuthor.getURL().toString(), extension.getAuthors().get(0).getUrl());
+        assertEquals("1.0", extension.getVersion());
+
+=====================================================================
+Found a 15 line (150 tokens) duplication in the following files: 
+Starting at line 249 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPluginTest.java
+Starting at line 143 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPluginTest.java
+
+        DocumentReference documentReference = new DocumentReference("xwiki", "MySpace", "MySSXPage");
+        when(this.currentEntityReferenceResolver.resolve(resource, EntityType.DOCUMENT)).thenReturn(documentReference);
+        when(this.entityReferenceSerializer.serialize(documentReference)).thenReturn(resource);
+
+        when(this.documentReferenceResolver.resolve(resource)).thenReturn(documentReference);
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(this.mockitoOldcore.getSpyXWiki().getDocument(documentReference, context)).thenReturn(document);
+
+        DocumentReference userReference = new DocumentReference("xwiki", "XWiki", "Foo");
+        when(document.getAuthorReference()).thenReturn(userReference);
+        when(this.authorizationManager.hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference, documentReference))
+            .thenReturn(true);
+
+        this.skinExtensionPlugin.use(resource, parameters, context);
+        String className = CssSkinExtensionPlugin.class.getCanonicalName();
+
+=====================================================================
+Found a 31 line (149 tokens) duplication in the following files: 
+Starting at line 108 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/XARImportIT.java
+Starting at line 149 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/XARImportIT.java
+
+        this.sectionPage.selectPackage(PACKAGE_WITH_HISTORY);
+
+        this.sectionPage.selectReplaceHistoryOption();
+        this.sectionPage.importPackage();
+
+        ViewPage importedPage = this.sectionPage.clickImportedPage("Main.TestPage");
+
+        // Since the page by default opens the comments pane, if we instantly click on the history, the two tabs
+        // will race for completion. Let's wait for comments first.
+        importedPage.openCommentsDocExtraPane();
+        HistoryPane history = importedPage.openHistoryDocExtraPane();
+
+        assertEquals("3.1", history.getCurrentVersion());
+        assertEquals("A third version of the document", history.getCurrentVersionComment());
+        assertTrue(history.hasVersionWithSummary("A new version of the document"));
+
+        AttachmentsPane attachments = new AttachmentsViewPage().openAttachmentsDocExtraPane();
+
+        assertEquals(1, attachments.getNumberOfAttachments());
+        assertEquals("3 bytes", attachments.getSizeOfAttachment(ATTACHE_NAME));
+        assertEquals("1.2", attachments.getLatestVersionOfAttachment(ATTACHE_NAME));
+
+        attachments.getAttachmentLink(ATTACHE_NAME).click();
+        assertEquals("1.2", setup.getDriver().findElement(By.tagName("html")).getText());
+    }
+
+    /**
+     * Verify that the Import page doesn't list any package by default in default XE.
+     */
+    @Test
+    void testImportHasNoPackageByDefault()
+
+=====================================================================
+Found a 33 line (149 tokens) duplication in the following files: 
+Starting at line 524 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+Starting at line 663 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+
+            assertEquals(currentMajor + ".1", historyPane.getCurrentVersion());
+
+            // Check that the page remained with rights unchanged
+            setup.gotoPage(xwikiPreferences, "edit", "editor=object");
+            objectEditPage = new ObjectEditPage();
+            rightObjects = objectEditPage.getObjectsOfClass("XWiki.XWikiGlobalRights", false);
+            rightObject = rightObjects.get(rightObjects.size() - 1);
+            rightObject.displayObject();
+            assertEquals(deleteVersionTestUser,
+                rightObject.getFieldValue(rightObject.byPropertyName("users")));
+            assertEquals("programming", rightObject.getFieldValue(rightObject.byPropertyName("levels")));
+            assertEquals("0", rightObject.getFieldValue(rightObject.byPropertyName("allow")));
+            // We don't use the Cancel button to leave the edit mode because the XWiki preferences sheet redirects to
+            // "admin" mode which locks back the page. Instead, we go to a page that doesn't add the edit lock back.
+            setup.gotoPage(xwikiPreferences.getLastSpaceReference());
+        } finally {
+            // Put back the page in the state it was before our changes
+            setup.loginAsSuperAdmin();
+            setup.gotoPage(xwikiPreferences, "view", "viewer=history");
+            historyPane = new HistoryPane();
+            historyPane = historyPane.showMinorEdits();
+            historyPane.rollbackToVersion(latestVersionBeforeChanges);
+        }
+    }
+
+    /**
+     * Scenario:
+     *   * Same as above but using DeleteVersionTestUserCancelEvent as user to trigger the
+     *   {@link org.xwiki.test.CustomUserUpdatedDocumentEventListener} which should cancel immediately the change
+     *   * Expectation here is that the reset is not performed at all
+     */
+    @Test
+    @Order(9)
+
+=====================================================================
+Found a 17 line (149 tokens) duplication in the following files: 
+Starting at line 131 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 612 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        when(ldQuery.getLimit()).thenReturn(limit);
+
+        LiveDataQuery.SortEntry sortEntry1 = mock(LiveDataQuery.SortEntry.class, "sortEntry1");
+        when(sortEntry1.isDescending()).thenReturn(false);
+        when(sortEntry1.getProperty()).thenReturn("scope");
+
+        LiveDataQuery.SortEntry sortEntry2 = mock(LiveDataQuery.SortEntry.class, "sortEntry2");
+        when(sortEntry2.isDescending()).thenReturn(true);
+        when(sortEntry2.getProperty()).thenReturn("isEnabled");
+
+        LiveDataQuery.SortEntry sortEntry3 = mock(LiveDataQuery.SortEntry.class, "sortEntry3");
+        when(sortEntry3.isDescending()).thenReturn(true);
+        when(sortEntry3.getProperty()).thenReturn("notificationFormats");
+
+        when(ldQuery.getSort()).thenReturn(List.of(sortEntry1, sortEntry2, sortEntry3));
+
+        String queryString = "select nfp from DefaultNotificationFilterPreference nfp where owner = :owner "
+
+=====================================================================
+Found a 17 line (149 tokens) duplication in the following files: 
+Starting at line 182 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 486 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 612 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        when(ldQuery.getLimit()).thenReturn(limit);
+
+        LiveDataQuery.SortEntry sortEntry1 = mock(LiveDataQuery.SortEntry.class, "sortEntry1");
+        when(sortEntry1.isDescending()).thenReturn(false);
+        when(sortEntry1.getProperty()).thenReturn("scope");
+
+        LiveDataQuery.SortEntry sortEntry2 = mock(LiveDataQuery.SortEntry.class, "sortEntry2");
+        when(sortEntry2.isDescending()).thenReturn(true);
+        when(sortEntry2.getProperty()).thenReturn("isEnabled");
+
+        LiveDataQuery.SortEntry sortEntry3 = mock(LiveDataQuery.SortEntry.class, "sortEntry3");
+        when(sortEntry3.isDescending()).thenReturn(true);
+        when(sortEntry3.getProperty()).thenReturn("notificationFormats");
+
+        when(ldQuery.getSort()).thenReturn(List.of(sortEntry1, sortEntry2, sortEntry3));
+
+        String queryString = "select count(nfp.id) from DefaultNotificationFilterPreference nfp where owner = :owner";
+
+=====================================================================
+Found a 24 line (149 tokens) duplication in the following files: 
+Starting at line 53 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/input/XWikiAttachmentContentInputSourceReferenceParserTest.java
+Starting at line 53 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/input/XWikiPageAttachmentContentInputSourceReferenceParserTest.java
+
+    private XWikiAttachmentContentInputSourceReferenceParser parser;
+
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
+    @MockComponent
+    private Environment environment;
+
+    @Test
+    void parse() throws FilterException, IOException, XWikiException
+    {
+        DocumentReference documentReference =
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "currentspace", "currentdocument");
+        XWikiDocument document = new XWikiDocument(documentReference);
+        document.setAttachment("file.txt", new ByteArrayInputStream("12345".getBytes()),
+            this.oldcore.getXWikiContext());
+        this.oldcore.getXWikiContext().setDoc(document);
+        this.oldcore.getXWikiContext().getWiki().saveDocument(document, this.oldcore.getXWikiContext());
+
+        XWikiAttachmentContentInputSource source = (XWikiAttachmentContentInputSource) this.parser.parse("file.txt");
+
+        assertEquals("12345", IOUtils.toString(source.getInputStream(), StandardCharsets.UTF_8));
+    }
+}
+
+=====================================================================
+Found a 13 line (148 tokens) duplication in the following files: 
+Starting at line 264 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/ConfigurableClassIT.java
+Starting at line 288 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/ConfigurableClassIT.java
+
+        FormContainerElement formContainerElement = asp.getFormContainerElementForClass(fullName);
+        assertEquals(String.format("%ssave/%s", setup.getBaseBinURL(), fullName.replace('.', '/')),
+            formContainerElement.getFormAction());
+        assertEquals(setup.getDriver().getCurrentUrl(),
+            formContainerElement.getFieldValue(By.name("xredirect")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_String")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_Boolean")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_TextArea")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_Select")));
+        assertTrue(formContainerElement.hasField(By.id(fullName + "_redirect")));
+
+        // Check it's not available in space section.
+        asp = AdministrationSectionPage.gotoSpaceAdministration(testReference.getLastSpaceReference(), section);
+
+=====================================================================
+Found a 17 line (147 tokens) duplication in the following files: 
+Starting at line 56 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/DocObjectChangedRule.java
+Starting at line 77 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/DocObjectChangedRule.java
+
+        Vector vobj2 = (olddoc == null) ? null : olddoc.getObjects(classname);
+        if ((vobj1 == null) && (vobj2 == null))
+            return true;
+        if ((vobj1 == null) || (vobj2 == null))
+            return false;
+        if (vobj1.size() != vobj2.size())
+            return false;
+        for (int i = 0; i < vobj1.size(); i++) {
+            if (!((vobj1.get(i) == null) && (vobj2.get(i) == null))) {
+                if ((vobj1.get(i) == null) || (vobj2.get(i) == null))
+                    return false;
+                if (!vobj1.get(i).equals(vobj2.get(i)))
+                    return false;
+            }
+        }
+        return true;
+    }
+
+=====================================================================
+Found a 13 line (147 tokens) duplication in the following files: 
+Starting at line 136 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 451 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 479 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+            notificationsUserProfilePage.getEventType(SYSTEM, UPDATE).getEventTypeDescription());
+
+        // Check default
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, EMAIL_FORMAT));
+
+=====================================================================
+Found a 17 line (147 tokens) duplication in the following files: 
+Starting at line 265 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentArchiveTest.java
+Starting at line 297 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentArchiveTest.java
+
+    void getNodes() throws XWikiException
+    {
+        XWikiDocument doc = new XWikiDocument(new DocumentReference("Test", "Test", "Test"));
+        XWikiDocumentArchive archive = new XWikiDocumentArchive(doc.getId());
+        doc.setDocumentArchive(archive);
+        String author = "XWiki.some author";
+
+        addRevisionToHistory(archive, doc, "content 1.1", author, "initial 1.1");
+
+        doc.setContent("content 2.1\nqwe @ ");
+        archive.updateArchive(doc, author, new Date(), "2.1", new Version(2,1), context);
+
+        doc.setContent("content 2.2\nqweq@ ");
+        archive.updateArchive(doc, author, new Date(), "2.2", new Version(2,2), context);
+
+        doc.setContent("content 2.3\nqweqe @@");
+        archive.updateArchive(doc, author, new Date(), "2.3", new Version(2,3), context);
+
+=====================================================================
+Found a 19 line (147 tokens) duplication in the following files: 
+Starting at line 822 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+Starting at line 854 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+
+    void restoreDeletedDocumentNoRights() throws Exception
+    {
+        long deletedDocumentId = 42;
+        DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
+        String deletedDocumentFullName = "space.page";
+
+        XWikiDeletedDocument deletedDocument = mock(XWikiDeletedDocument.class);
+        when(deletedDocument.getDocumentReference()).thenReturn(documentReference);
+        when(deletedDocument.getId()).thenReturn(deletedDocumentId);
+        when(deletedDocument.getFullName()).thenReturn(deletedDocumentFullName);
+        when(xwiki.getDeletedDocument(deletedDocumentId, xcontext)).thenReturn(deletedDocument);
+
+        when(xwiki.exists(documentReference, xcontext)).thenReturn(false);
+        when(recycleBin.getDeletedDocument(deletedDocumentId, xcontext, true)).thenReturn(deletedDocument);
+
+        // No rights.
+        XWikiRightService rightService = mock(XWikiRightService.class);
+        when(xwiki.getRightService()).thenReturn(rightService);
+        when(recycleBin.hasAccess(any(), any(), any())).thenReturn(false);
+
+=====================================================================
+Found a 17 line (147 tokens) duplication in the following files: 
+Starting at line 131 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-api/src/test/java/org/xwiki/sheet/internal/SheetDocumentDisplayerTest.java
+Starting at line 168 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-api/src/test/java/org/xwiki/sheet/internal/SheetDocumentDisplayerTest.java
+
+        setCurrentDocument(document);
+
+        SheetManager sheetManager = this.mocker.getInstance(SheetManager.class);
+        when(sheetManager.getSheets(document, "view")).thenReturn(Collections.singletonList(SHEET_REFERENCE));
+
+        DocumentModelBridge originalSecurityDoc = mock(DocumentModelBridge.class, "sdoc");
+        // Required in order to preserve the programming rights of the sheet.
+        when(this.modelBridge.setSecurityDocument(sheet)).thenReturn(originalSecurityDoc);
+
+        XDOM output = new XDOM(Collections.<Block>emptyList());
+        DocumentDisplayer documentDisplayer = this.mocker.getInstance(DocumentDisplayer.class);
+        when(documentDisplayer.display(eq(sheet), any(DocumentDisplayerParameters.class))).thenReturn(output);
+
+        assertSame(output, this.mocker.getComponentUnderTest().display(document, new DocumentDisplayerParameters()));
+
+        // The security document must be reverted.
+        verify(this.modelBridge).setSecurityDocument(originalSecurityDoc);
+
+=====================================================================
+Found a 21 line (146 tokens) duplication in the following files: 
+Starting at line 109 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-storage/src/test/java/org/xwiki/mail/script/DeprecatedMailStorageScriptServiceTest.java
+Starting at line 183 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/test/java/org/xwiki/mail/script/MailStorageScriptServiceTest.java
+
+        Map filterMap = Collections.singletonMap("state", "prepare_%");
+
+        MailStatus status1 = new MailStatus();
+        status1.setBatchId("batch1");
+        status1.setMessageId("message1");
+
+        MailStatus status2 = new MailStatus();
+        status2.setBatchId("batch2");
+        status2.setMessageId("message2");
+
+        MailStatusResult statusResult1 = mock(MailStatusResult.class, "status1");
+        when(statusResult1.getTotalMailCount()).thenReturn(1L);
+
+        MailStatusResult statusResult2 = mock(MailStatusResult.class, "status2");
+        when(statusResult2.getTotalMailCount()).thenReturn(2L);
+
+        List<Pair<MailStatus, MailStatusResult>> results = new ArrayList<>();
+        results.add(new ImmutablePair<>(status1, statusResult1));
+        results.add(new ImmutablePair<>(status2, statusResult2));
+
+        MailResender resender = this.mocker.getInstance(MailResender.class, "database");
+
+=====================================================================
+Found a 19 line (146 tokens) duplication in the following files: 
+Starting at line 77 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 153 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        when(ldQuery.getLimit()).thenReturn(limit);
+        when(query.setOffset(offset.intValue())).thenReturn(query);
+        when(query.setLimit(limit)).thenReturn(query);
+
+        List<Object> expectedList = List.of(
+            mock(NotificationFilterPreference.class, "filterPref1"),
+            mock(NotificationFilterPreference.class, "filterPref2"),
+            mock(NotificationFilterPreference.class, "filterPref3")
+        );
+        when(query.execute()).thenReturn(expectedList);
+        assertEquals(expectedList, this.queryHelper.getFilterPreferences(ldQuery, owner, wikiReference));
+        verify(query).bindValue("owner", owner);
+        verify(query).setWiki(wikiName);
+        verify(query).setOffset(offset.intValue());
+        verify(query).setLimit(limit);
+    }
+
+    @Test
+    void countFilterPreferencesNoFilterNoSort() throws QueryException, LiveDataException
+
+=====================================================================
+Found a 19 line (146 tokens) duplication in the following files: 
+Starting at line 922 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1553 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void existingDocumentFromUITemplateProviderSpecified() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
+        String templateProviderFullName = "XWiki.MyTemplateProvider";
+        when(mockRequest.getParameter("spaceReference")).thenReturn("X");
+        when(mockRequest.getParameter("name")).thenReturn("Y");
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+
+        // Mock 1 existing template provider
+        mockExistingTemplateProviders(templateProviderFullName,
+            new DocumentReference("xwiki", Arrays.asList("XWiki"), "MyTemplateProvider"), Collections.emptyList());
+
+=====================================================================
+Found a 18 line (145 tokens) duplication in the following files: 
+Starting at line 120 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/html/HTMLMimeBodyPartFactoryTest.java
+Starting at line 154 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/html/HTMLMimeBodyPartFactoryTest.java
+
+    public void createWhenHTMLAndEmbeddedImagesAndNormalAttachments() throws Exception
+    {
+        Attachment normalAttachment = mock(Attachment.class, "normalAttachment");
+        when(normalAttachment.getFilename()).thenReturn("attachment1.png");
+        Attachment embeddedAttachment = mock(Attachment.class, "embeddedAttachment");
+        when(embeddedAttachment.getFilename()).thenReturn("embeddedAttachment.png");
+
+        MimeBodyPart embeddedAttachmentBodyPart = mock(MimeBodyPart.class);
+        MimeBodyPartFactory attachmentBodyPartFactory = this.componentManager.getInstance(
+            new DefaultParameterizedType(null, MimeBodyPartFactory.class, Attachment.class), "xwiki/attachment");
+        when(attachmentBodyPartFactory.create(same(embeddedAttachment), any(Map.class))).thenReturn(
+            embeddedAttachmentBodyPart);
+
+        MimeBodyPart normalAttachmentBodyPart = mock(MimeBodyPart.class);
+        when(attachmentBodyPartFactory.create(same(normalAttachment), any(Map.class))).thenReturn(
+            normalAttachmentBodyPart);
+
+        MimeBodyPart bodyPart = this.htmlMimeBodyPartFactory.create(
+
+=====================================================================
+Found a 13 line (145 tokens) duplication in the following files: 
+Starting at line 68 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+Starting at line 212 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+
+        assertEquals(Locale.ENGLISH, document.getDefaultLocale());
+        assertEquals(new DocumentReference("wiki", "space", "parent"), document.getParentReference());
+        assertEquals("customclass", document.getCustomClass());
+        assertEquals("title", document.getTitle());
+        assertEquals("defaultTemplate", document.getDefaultTemplate());
+        assertEquals("validationScript", document.getValidationScript());
+        assertEquals(new Syntax(new SyntaxType("syntax", "syntax"), "1.0"), document.getSyntax());
+        assertEquals(true, document.isHidden());
+        assertEquals("content", document.getContent());
+
+        assertEquals(new DocumentReference("wiki", "XWiki", "creator"), document.getCreatorReference());
+        assertEquals(toDate("2000-01-01 00:00:00.0 UTC"), document.getCreationDate());
+        assertEquals(new DocumentReference("wiki", "XWiki", "author"), document.getAuthorReference());
+
+=====================================================================
+Found a 18 line (145 tokens) duplication in the following files: 
+Starting at line 174 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+Starting at line 236 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+
+        verify(this.criteriaQueryLong).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(2, predicates.size());
+
+        ComparisonPredicate idPredicate = (ComparisonPredicate) predicates.get(0);
+        LiteralExpression<Long> idExpression = (LiteralExpression<Long>) idPredicate.getRightHandOperand();
+        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, idPredicate.getComparisonOperator());
+        assertEquals("mocked id.docId", idPredicate.getLeftHandOperand().toString());
+        assertEquals(42L, idExpression.getLiteral());
+
+        NullnessPredicate nonNullDiffPredicate = (NullnessPredicate) predicates.get(1);
+        assertTrue(nonNullDiffPredicate.isNegated());
+        assertEquals("mocked diff", nonNullDiffPredicate.getOperand().toString());
+    }
+
+    @Test
+    void testRCSNodeInfoCountQueryWithAuthorCriteria()
+
+=====================================================================
+Found a 20 line (145 tokens) duplication in the following files: 
+Starting at line 957 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1325 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1402 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void existingDocumentFromUITemplateProviderSpecifiedRestrictionExists() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
+        String templateProviderFullName = "XWiki.MyTemplateProvider";
+        String spaceReferenceString = "X";
+        when(mockRequest.getParameter("spaceReference")).thenReturn(spaceReferenceString);
+        when(mockRequest.getParameter("name")).thenReturn("Y");
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+
+        // Mock 1 existing template provider that allows usage in target space.
+        mockExistingTemplateProviders(templateProviderFullName,
+            new DocumentReference("xwiki", Arrays.asList("XWiki"), "MyTemplateProvider"), Arrays.asList("X"));
+
+=====================================================================
+Found a 17 line (143 tokens) duplication in the following files: 
+Starting at line 162 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/test/java/org/xwiki/notifications/preferences/script/NotificationPreferenceScriptServiceTest.java
+Starting at line 215 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/test/java/org/xwiki/notifications/preferences/script/NotificationPreferenceScriptServiceTest.java
+
+            .isEventTypeEnabledForUser("update", NotificationFormat.ALERT, documentUserReference));
+
+        NotificationPreference pref1 = mock(NotificationPreference.class);
+        NotificationPreference pref2 = mock(NotificationPreference.class);
+
+        when(pref1.getFormat()).thenReturn(NotificationFormat.EMAIL);
+        Map<NotificationPreferenceProperty, Object> properties1 = new HashMap<>();
+        properties1.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
+        when(pref1.getProperties()).thenReturn(properties1);
+
+        when(pref2.getFormat()).thenReturn(NotificationFormat.ALERT);
+        Map<NotificationPreferenceProperty, Object> properties2 = new HashMap<>();
+        properties2.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
+        when(pref2.getProperties()).thenReturn(properties2);
+        when(pref2.isNotificationEnabled()).thenReturn(true);
+
+        when(notificationPreferenceManager.getAllPreferences(user)).thenReturn(Arrays.asList(pref1, pref2));
+
+=====================================================================
+Found a 15 line (143 tokens) duplication in the following files: 
+Starting at line 267 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentArchiveTest.java
+Starting at line 350 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentArchiveTest.java
+
+        XWikiDocument doc = new XWikiDocument(new DocumentReference("Test", "Test", "Test"));
+        XWikiDocumentArchive archive = new XWikiDocumentArchive(doc.getId());
+        doc.setDocumentArchive(archive);
+        String author = "XWiki.some author";
+
+        addRevisionToHistory(archive, doc, "content 1.1", author, "initial 1.1");
+
+        doc.setContent("content 2.1\nqwe @ ");
+        archive.updateArchive(doc, author, new Date(), "2.1", new Version(2,1), context);
+
+        doc.setContent("content 2.2\nqweq@ ");
+        archive.updateArchive(doc, author, new Date(), "2.2", new Version(2,2), context);
+
+        doc.setContent("content 2.3\nqweqe @@");
+        archive.updateArchive(doc, author, new Date(), "2.3", new Version(2,3), context);
+
+=====================================================================
+Found a 20 line (142 tokens) duplication in the following files: 
+Starting at line 325 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+Starting at line 382 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+
+    void readObjectsFromFormUpdateOrCreate() throws Exception
+    {
+        this.document = new XWikiDocument(new DocumentReference(DOCWIKI, DOCSPACE, DOCNAME));
+        this.oldcore.getSpyXWiki().saveDocument(this.document, "", true, this.oldcore.getXWikiContext());
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        MockitoComponentManager mocker = this.oldcore.getMocker();
+        XWikiContext context = this.oldcore.getXWikiContext();
+        DocumentReferenceResolver<String> documentReferenceResolverString =
+            mocker.registerMockComponent(DocumentReferenceResolver.TYPE_STRING, "current");
+        // Entity Reference resolver is used in <BaseObject>.getXClass()
+        DocumentReferenceResolver<EntityReference> documentReferenceResolverEntity =
+            mocker.registerMockComponent(DocumentReferenceResolver.TYPE_REFERENCE, "current");
+
+        Map<String, String[]> parameters = generateFakeRequestMap();
+        BaseClass baseClass = generateFakeClass();
+        generateFakeObjects();
+        EditForm eform = new EditForm();
+
+        when(request.getParameter("objectPolicy")).thenReturn("updateOrCreate");
+
+=====================================================================
+Found a 9 line (142 tokens) duplication in the following files: 
+Starting at line 291 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-tests/src/test/it/org/xwiki/repository/test/ui/repository/RepositoryIT.java
+Starting at line 346 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-tests/src/test/it/org/xwiki/repository/test/ui/repository/RepositoryIT.java
+
+            getUtil().rest().getResource(Resources.EXTENSION_VERSION, null, this.baseExtension.getId().getId(), "10.0");
+
+        assertEquals(this.baseExtension.getId().getId(), extension.getId());
+        assertEquals(this.baseExtension.getType(), extension.getType());
+        assertEquals(this.baseExtension.getSummary(), extension.getSummary());
+        assertEquals(this.baseLicense.getName(), extension.getLicenses().get(0).getName());
+        assertEquals(this.baseAuthor.getName(), extension.getAuthors().get(0).getName());
+        assertEquals(this.baseAuthor.getURL().toString(), extension.getAuthors().get(0).getUrl());
+        assertEquals("10.0", extension.getVersion());
+
+=====================================================================
+Found a 22 line (142 tokens) duplication in the following files: 
+Starting at line 55 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentsResourceImpl.java
+Starting at line 50 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentsVersionResourceImpl.java
+
+            DocumentInfo documentInfo = getDocumentInfo(wikiName, spaceName, pageName, null, null, true, false);
+
+            Document doc = documentInfo.getDocument();
+
+            Comments comments = objectFactory.createComments();
+
+            Vector<com.xpn.xwiki.api.Object> xwikiComments = doc.getComments();
+
+            RangeIterable<com.xpn.xwiki.api.Object> ri =
+                    new RangeIterable<com.xpn.xwiki.api.Object>(xwikiComments, start, number);
+
+            for (com.xpn.xwiki.api.Object xwikiComment : ri) {
+                comments.getComments().add(
+                        DomainObjectFactory.createComment(objectFactory, uriInfo.getBaseUri(), doc, xwikiComment,
+                                Utils.getXWikiApi(componentManager), withPrettyNames));
+            }
+
+            return comments;
+        } catch (XWikiException e) {
+            throw new XWikiRestException(e);
+        }
+    }
+
+=====================================================================
+Found a 14 line (141 tokens) duplication in the following files: 
+Starting at line 293 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+Starting at line 344 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+
+        verify(query).bindValue(BIND_KEYID, ENCODED_SUBJECTKEYID);
+        verify(query).bindValue(BIND_STORE, FULLNAME);
+
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_KEYID), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_ISSUER), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SERIAL), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SUBJECT), any(String.class));
+        verify(certObj).setLargeStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_CERTIFICATE, ENCODED_CERTIFICATE);
+
+        verify(xwiki).saveDocument(storeDoc, xcontext);
+    }
+
+    @Test
+    public void testUpdatingCertificateWithKeyIdToSpace() throws Exception
+
+=====================================================================
+Found a 16 line (141 tokens) duplication in the following files: 
+Starting at line 262 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 513 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filters = Arrays.asList(notificationFilter1, notificationFilter2);
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_DOCUMENT, "someValue1", CompareType.EQUALS, false),
+
+=====================================================================
+Found a 19 line (141 tokens) duplication in the following files: 
+Starting at line 922 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1033 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1553 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void existingDocumentFromUITemplateProviderSpecified() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
+        String templateProviderFullName = "XWiki.MyTemplateProvider";
+        when(mockRequest.getParameter("spaceReference")).thenReturn("X");
+        when(mockRequest.getParameter("name")).thenReturn("Y");
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+
+        // Mock 1 existing template provider
+        mockExistingTemplateProviders(templateProviderFullName,
+            new DocumentReference("xwiki", Arrays.asList("XWiki"), "MyTemplateProvider"), Collections.emptyList());
+
+=====================================================================
+Found a 7 line (141 tokens) duplication in the following files: 
+Starting at line 293 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-tests/src/test/it/org/xwiki/repository/test/ui/repository/RepositoryIT.java
+Starting at line 327 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-tests/src/test/it/org/xwiki/repository/test/ui/repository/RepositoryIT.java
+Starting at line 348 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-tests/src/test/it/org/xwiki/repository/test/ui/repository/RepositoryIT.java
+
+        assertEquals(this.baseExtension.getId().getId(), extension.getId());
+        assertEquals(this.baseExtension.getType(), extension.getType());
+        assertEquals(this.baseExtension.getSummary(), extension.getSummary());
+        assertEquals(this.baseLicense.getName(), extension.getLicenses().get(0).getName());
+        assertEquals(this.baseAuthor.getName(), extension.getAuthors().get(0).getName());
+        assertEquals(this.baseAuthor.getURL().toString(), extension.getAuthors().get(0).getUrl());
+        assertEquals("10.0", extension.getVersion());
+
+=====================================================================
+Found a 28 line (141 tokens) duplication in the following files: 
+Starting at line 63 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetgroupsPageTest.java
+Starting at line 63 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetusersPageTest.java
+
+    private TemplateManager templateManager;
+
+    private XWikiGroupService groupService;
+
+    private ContextualAuthorizationManager contextualAuthorizationManager;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        this.templateManager = this.oldcore.getMocker().getInstance(TemplateManager.class);
+
+        // Enable the Rights Manager plugin.
+        this.oldcore.getSpyXWiki().getPluginManager().addPlugin("rightsmanager", RightsManagerPlugin.class.getName(),
+            this.oldcore.getXWikiContext());
+
+        this.groupService = this.context.getWiki().getGroupService(this.context);
+
+        this.contextualAuthorizationManager = this.componentManager.getInstance(ContextualAuthorizationManager.class);
+    }
+
+    @Test
+    void removeObuscatedResultsWhenTotalrowsLowerThanLimit() throws Exception
+    {
+        this.request.put("wiki", "local");
+        this.request.put("limit", "10");
+        this.request.put("offset", "1");
+
+        DocumentReference group1DocumentReference = new DocumentReference("xwiki", "XWiki", "G1");
+
+=====================================================================
+Found a 28 line (140 tokens) duplication in the following files: 
+Starting at line 759 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+Starting at line 202 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+
+        return rawvalue.toString();
+    }
+
+    @Override
+    public void displayHidden(StringBuffer buffer, String name, String prefix, BaseCollection object,
+        XWikiContext context)
+    {
+        input input = new input();
+        input.setAttributeFilter(new XMLAttributeValueFilter());
+        BaseProperty prop = (BaseProperty) object.safeget(name);
+        if (prop != null) {
+            input.setValue(prop.toText());
+        }
+
+        input.setType("hidden");
+        input.setName(prefix + name);
+        input.setID(prefix + name);
+        buffer.append(input.toString());
+    }
+
+    @Override
+    public void displayView(StringBuffer buffer, String name, String prefix, BaseCollection object,
+        XWikiContext context)
+    {
+        BaseProperty prop = (BaseProperty) object.safeget(name);
+
+        // Skip unset values.
+        if (prop == null) {
+
+=====================================================================
+Found a 19 line (140 tokens) duplication in the following files: 
+Starting at line 201 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/resolver/DefaultResourceReferenceEntityReferenceResolverTest.java
+Starting at line 202 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/resolver/RelativeResourceReferenceEntityReferenceResolverTest.java
+
+            any())).thenReturn(new DocumentReference(WIKI, SPACE, PAGE));
+
+        ResourceReference withBaseReference = documentResource("", true);
+        withBaseReference.addBaseReference(WIKI + ':' + SPACE + '.' + PAGE);
+        assertEquals(new DocumentReference(WIKI, SPACE, PAGE),
+            this.resolver.resolve(withBaseReference, null));
+
+        assertEquals(new DocumentReference(WIKI, SPACE, PAGE), this.resolver
+            .resolve(documentResource("", true), null, new DocumentReference(WIKI, SPACE, PAGE)));
+    }
+
+    @Test
+    void resolveUntypeDocument()
+    {
+        // When the page does not exist
+
+        assertEquals(new DocumentReference(WIKI, List.of(SPACE, PAGE), DEFAULT_PAGE),
+            this.resolver.resolve(documentResource(WIKI + ':' + SPACE + '.' + PAGE, false), null));
+        assertEquals(new DocumentReference(CURRENT_WIKI, List.of(SPACE, PAGE), DEFAULT_PAGE),
+
+=====================================================================
+Found a 13 line (140 tokens) duplication in the following files: 
+Starting at line 145 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+Starting at line 173 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+
+        verify(this.velocityEngine, never()).evaluate(any(), any(), any(), eq(this.testString));
+
+        Element presentationLink =
+            result.getElementsByAttributeValue("role", "presentation").get(0).getElementsByTag("a").get(0);
+        // Escaping tests only.
+        assertEquals("#" + this.testString + "SearchSuggestSources", presentationLink.attr("href"));
+        assertEquals(this.testString, presentationLink.text());
+        assertEquals(this.testString + "SearchSuggestSources", presentationLink.attr("aria-controls"));
+        assertEquals(this.testString + "SearchSuggestSources", result.getElementsByClass("tab-pane").get(0).attr("id"));
+        assertEquals(this.testString, result.getElementsByClass("limit").text());
+
+        // These should not be evaluated.
+        assertEquals(this.testString, result.getElementsByClass("icon").get(0).attr("src"));
+
+=====================================================================
+Found a 22 line (139 tokens) duplication in the following files: 
+Starting at line 90 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/test/java/org/xwiki/notifications/sources/internal/QueryGeneratorTest.java
+Starting at line 155 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/test/java/org/xwiki/notifications/sources/internal/QueryGeneratorTest.java
+
+    public void generateQueryExpression() throws Exception
+    {
+        // Test
+        NotificationParameters parameters = new NotificationParameters();
+        parameters.user = USER_REFERENCE;
+        parameters.format = NotificationFormat.ALERT;
+        parameters.fromDate = startDate;
+        parameters.preferences = Arrays.asList(pref1);
+        parameters.filterPreferences = Arrays.asList(fakeFilterPreference);
+        ExpressionNode node = this.queryGenerator.generateQueryExpression(parameters);
+
+        // Verify
+        assertEquals("((DATE >= \"" + this.startDate.toString() + "\" " + "AND (TYPE = \"create\" AND DATE >= \""
+            + this.pref1StartDate.toString() + "\")) AND HIDDEN <> true) " + "ORDER BY DATE DESC", node.toString());
+
+        // Test 2
+        this.queryGenerator.generateQuery(parameters);
+
+        verify(this.queryManager).createQuery("where ((" + "event.date >= :" + this.startDateParamName + ") "
+            + "AND ((event.type = :value_fa8847b0c33183273f5945508b31c3208a9e4ece58ca47233a05628d8dba3799) "
+            + "AND (event.date >= :" + this.pref1StartDateParamName + "))) " + "AND (event.hidden <> true) "
+            + "ORDER BY event.date DESC", Query.HQL);
+
+=====================================================================
+Found a 14 line (139 tokens) duplication in the following files: 
+Starting at line 104 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+Starting at line 311 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+Starting at line 376 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+Starting at line 563 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+
+        GetMethod getMethod =
+            executeGet(buildURI(PageResource.class, getWiki(), this.spaces, this.pageName).toString());
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Page page = (Page) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+        Link link = getFirstLinkByRelation(page, Relations.OBJECTS);
+        Assert.assertNotNull(link);
+
+        getMethod = executeGet(link.getHref());
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Objects objects = (Objects) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+
+        Assert.assertFalse(objects.getObjectSummaries().isEmpty());
+
+=====================================================================
+Found a 10 line (138 tokens) duplication in the following files: 
+Starting at line 396 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/ModelBridgeTest.java
+Starting at line 423 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/ModelBridgeTest.java
+
+        entry.put("customField", "value");
+        DocumentReference documentReference = new DocumentReference("xwiki", "MyTest", "MyDoc");
+        DocumentReference defaultClassReference = new DocumentReference("xwiki", "MyTest", "MyClass");
+        DocumentReference customClassReference = new DocumentReference("xwiki", "MyTest", "CustomClass");
+
+        when(this.xwiki.getDocument(documentReference, this.xcontext)).thenReturn(this.document);
+        when(this.document.getXObject(customClassReference, 0)).thenReturn(this.baseObject);
+        when(this.baseObject.getXClass(this.xcontext)).thenReturn(this.baseClass);
+        when(this.baseObject.getPropertyNames()).thenReturn(new String[] { "customField" });
+        when(this.baseObject.get("customField")).thenReturn(this.propertyInterface);
+
+=====================================================================
+Found a 34 line (138 tokens) duplication in the following files: 
+Starting at line 190 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+Starting at line 204 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+
+        buffer.append(in.toString());
+    }
+
+    @Override
+    public BaseProperty newPropertyfromXML(Element ppcel) throws XWikiException
+    {
+        String value = ppcel.getText();
+        return fromString(value);
+    }
+
+    @Override
+    public List<String> toList(BaseProperty<?> property)
+    {
+        List<String> selectlist;
+
+        if (property == null) {
+            selectlist = Collections.emptyList();
+        } else {
+            selectlist = getListFromString((String) property.getValue());
+        }
+
+        return selectlist;
+    }
+
+    @Override
+    public <T extends EntityReference> void mergeProperty(BaseProperty<T> currentProperty,
+        BaseProperty<T> previousProperty, BaseProperty<T> newProperty, MergeConfiguration configuration,
+        XWikiContext xcontext, MergeResult mergeResult)
+    {
+        // always a not ordered list
+        mergeNotOrderedListProperty(currentProperty, previousProperty, newProperty, configuration, xcontext,
+            mergeResult);
+    }
+}
+
+=====================================================================
+Found a 17 line (138 tokens) duplication in the following files: 
+Starting at line 743 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+Starting at line 771 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+
+    void restoreDocumentTranslation() throws Exception
+    {
+        long deletedDocumentId = 42;
+        Locale locale = new Locale("ro");
+        DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
+        DocumentReference translationDocumentReference = new DocumentReference(documentReference, locale);
+
+        XWikiDeletedDocument deletedDocument = mock(XWikiDeletedDocument.class);
+        when(deletedDocument.getDocumentReference()).thenReturn(translationDocumentReference);
+        when(deletedDocument.getId()).thenReturn(deletedDocumentId);
+        when(xwiki.getDeletedDocument(deletedDocumentId, xcontext)).thenReturn(deletedDocument);
+
+        when(xwiki.exists(translationDocumentReference, xcontext)).thenReturn(false);
+        when(request.isCheckAuthorRights()).thenReturn(false);
+        when(request.isCheckRights()).thenReturn(false);
+
+        assertTrue(this.modelBridge.restoreDeletedDocument(deletedDocumentId, request));
+
+=====================================================================
+Found a 19 line (138 tokens) duplication in the following files: 
+Starting at line 104 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/CurrentDocumentStringUserReferenceResolverTest.java
+Starting at line 101 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DefaultDocumentStringUserReferenceResolverTest.java
+
+        when(this.documentReferenceResolver.resolve("page", new EntityReference("XWiki", EntityType.SPACE,
+            new EntityReference("somewiki", EntityType.WIKI)))).thenReturn(
+            new DocumentReference("somewiki", "XWiki", "page"));
+
+        UserReference reference = this.resolver.resolve("page", new WikiReference("somewiki"));
+        assertNotNull(reference);
+        assertTrue(reference instanceof DocumentUserReference);
+        assertEquals("somewiki:XWiki.page", ((DocumentUserReference) reference).getReference().toString());
+        assertFalse(reference.isGlobal());
+    }
+
+    @Test
+    void resolveGuest()
+    {
+        UserReference reference = this.resolver.resolve("XWikiGuest");
+        assertSame(GuestUserReference.INSTANCE, reference);
+
+        reference = this.resolver.resolve("xWiKiGuEsT");
+        assertSame(GuestUserReference.INSTANCE, reference);
+
+=====================================================================
+Found a 11 line (137 tokens) duplication in the following files: 
+Starting at line 318 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+Starting at line 371 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+
+        verify(query).bindValue(BIND_KEYID, ENCODED_SUBJECTKEYID);
+        verify(query).bindValue(BIND_STORE, SPACE);
+
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_KEYID), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_ISSUER), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SERIAL), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SUBJECT), any(String.class));
+        verify(certObj).setLargeStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_CERTIFICATE, ENCODED_CERTIFICATE);
+
+        verify(xwiki).saveDocument(storeDoc, xcontext);
+    }
+
+=====================================================================
+Found a 49 line (137 tokens) duplication in the following files: 
+Starting at line 82 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/PinnedChildPagesTab.java
+Starting at line 194 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/NavigationPanelAdministrationPage.java
+
+        WebElement buttonElement = getDriver().findElementWithoutWaiting(getTreeElement(),
+            By.xpath("(.//li[contains(@class, 'jstree-node')]/a[. = '" + pageTitle + "']/following-sibling::div"
+                + "[contains(@class, 'jstree-action')]/button)"));
+        getDriver().createActions().moveToElement(buttonElement).perform();
+        getDriver().waitUntilCondition(driver -> buttonElement.isDisplayed());
+        buttonElement.click();
+    }
+
+    /**
+     * Pin the given page if it's not pinned already.
+     * @param pageTitle the title of the page to pin.
+     */
+    public void pinPage(String pageTitle)
+    {
+        if (!isPinned(pageTitle)) {
+            togglePinnedPageStatus(pageTitle);
+        }
+    }
+
+    /**
+     * Unpin the page if it's pinned.
+     * @param pageTitle the title of the page to unpin.
+     */
+    public void unpinPage(String pageTitle)
+    {
+        if (isPinned(pageTitle)) {
+            togglePinnedPageStatus(pageTitle);
+        }
+    }
+
+    /**
+     * Drag the given page before the second page argument. Note that performing the drag&amp;drop should also perform a
+     * pin.
+     * @param pageTitleToDrag the title of the page to drag
+     * @param pageTitleToDropBefore the title of the page before which to drag
+     */
+    public void dragBefore(String pageTitleToDrag, String pageTitleToDropBefore)
+    {
+        WebElement pageItemToDrag = getPageByTitle(pageTitleToDrag);
+        WebElement pageItemToDropBefore = getPageByTitle(pageTitleToDropBefore);
+
+        getDriver().dragAndDrop(pageItemToDrag, pageItemToDropBefore);
+    }
+
+    /**
+     * Save the changes.
+     */
+    public void save()
+    {
+
+=====================================================================
+Found a 18 line (137 tokens) duplication in the following files: 
+Starting at line 631 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 693 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+        when(this.compactEntityReferenceSerializer.serialize(newLinkTarget, documentReference)).thenReturn("X.WebHome");
+        when(this.relativeEntityReferenceResolver.resolve(docLinkReference, null, null)).thenReturn(relativeReference);
+
+        // Space link
+        SpaceReference spaceReference = oldLinkTarget.getLastSpaceReference();
+        when(this.resourceReferenceResolver.resolve(spaceLinkReference, null))
+            .thenReturn(spaceReference);
+        when(this.resourceReferenceResolver.resolve(spaceLinkReference, null, documentReference))
+            .thenReturn(spaceReference);
+        when(this.defaultReferenceDocumentReferenceResolver.resolve(spaceReference)).thenReturn(oldLinkTarget);
+        when(this.compactEntityReferenceSerializer.serialize(newLinkTarget.getLastSpaceReference(), documentReference))
+            .thenReturn("X");
+        when(this.relativeEntityReferenceResolver.resolve(spaceLinkReference, null, null))
+            .thenReturn(relativeSpaceReference);
+
+        updater.update(documentReference, oldLinkTarget, newLinkTarget);
+
+        assertEquals("X.WebHome", documentLinkBlock.getReference().getReference());
+
+=====================================================================
+Found a 25 line (136 tokens) duplication in the following files: 
+Starting at line 201 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/test/java/org/xwiki/component/internal/ContextComponentManagerTest.java
+Starting at line 297 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/test/java/org/xwiki/component/internal/ContextComponentManagerTest.java
+Starting at line 355 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/test/java/org/xwiki/component/internal/ContextComponentManagerTest.java
+
+        state.become("otherdocument");
+        getMockery().checking(new Expectations()
+        {
+            {
+                exactly(1).of(mockDocumentAccessBridge).getCurrentUserReference();
+                will(returnValue(new DocumentReference("wiki", "XWiki", "user")));
+                allowing(mockWikiDescriptorManager).getCurrentWikiId();
+                will(returnValue("wiki2"));
+                allowing(mockCurrentSpaceReferenceProvider).get();
+                will(returnValue(new SpaceReference("space2", new WikiReference("wiki2"))));
+                allowing(mockCurrentDocumentReferenceProvider).get();
+                will(returnValue(new DocumentReference("wiki2", "space2", "document2")));
+            }
+        });
+
+        try {
+            contextCM.getInstance(Role.class);
+            Assert.fail("Should have raised an exception");
+        } catch (ComponentLookupException expected) {
+            // No need to assert the message, we just want to ensure an exception is raised.
+        }
+    }
+
+    @Test
+    public void testDeleteDocument() throws Exception
+
+=====================================================================
+Found a 13 line (136 tokens) duplication in the following files: 
+Starting at line 683 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 807 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        setFilter("name", "filtername");
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+        when(this.query.execute()).thenReturn(singletonList("Space.MyObject"));
+
+        renderPage();
+
+        List<Map<String, Object>> rows = getRows();
+        assertEquals(expectedMail, StringUtils.trim((String) rows.get(0).get("mail")));
+
+=====================================================================
+Found a 16 line (136 tokens) duplication in the following files: 
+Starting at line 97 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-rest/xwiki-platform-localization-rest-default/src/test/java/org/xwiki/localization/internal/DefaultTranslationsResourceTest.java
+Starting at line 202 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-rest/xwiki-platform-localization-rest-default/src/test/java/org/xwiki/localization/internal/DefaultTranslationsResourceTest.java
+
+    void getTranslations() throws Exception
+    {
+        ObjectFactory objectFactory = new ObjectFactory();
+        Translations expected = objectFactory.createTranslations();
+        expected.getTranslations().addAll(asList(
+            createTranslation(objectFactory, "key1", "value1"),
+            createTranslation(objectFactory, "key2", "value2")
+        ));
+
+        when(this.localizationManager.getTranslation("key1", this.defaultLocale)).thenReturn(this.translationKey1);
+        when(this.localizationManager.getTranslation("key2", this.defaultLocale)).thenReturn(this.translationKey2);
+        when(this.translationKey1.getRawSource()).thenReturn("value1");
+        when(this.translationKey2.getRawSource()).thenReturn("value2");
+
+        Translations response =
+            this.defaultTranslationResource.getTranslations("mywiki", null, null, asList("key1", "key2"));
+
+=====================================================================
+Found a 13 line (136 tokens) duplication in the following files: 
+Starting at line 294 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+Starting at line 478 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+
+        newObject.setLargeStringValue(TEXT_FIELD, newAwmContent);
+
+        XDOM oldXDOM = new XDOM(List.of(new WordBlock("oldword")));
+        when(this.xdomService.parse(oldAwmContent, XWIKI_2_1))
+            .thenReturn(Optional.of(oldXDOM));
+        XDOM newXDOM = new XDOM(List.of(new WordBlock("newword")));
+        when(this.xdomService.parse(newAwmContent, XWIKI_2_1))
+            .thenReturn(Optional.of(newXDOM));
+
+        List<MacroBlock> oldMentions = List.of(new MacroBlock("mention", new HashMap<>(), false));
+        when(this.xdomService.listMentionMacros(oldXDOM)).thenReturn(oldMentions);
+        List<MacroBlock> newMentions = List.of(
+            buildMentionMacro(USER_U1, "anchor1", FIRST_NAME),
+
+=====================================================================
+Found a 14 line (136 tokens) duplication in the following files: 
+Starting at line 152 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 299 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 528 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        when(query.bindValue("owner", owner)).thenReturn(query);
+        when(query.setWiki(wikiName)).thenReturn(query);
+        when(query.setOffset(offset.intValue())).thenReturn(query);
+        when(query.setLimit(limit)).thenReturn(query);
+
+        List<Object> expectedList = List.of(
+            mock(NotificationFilterPreference.class, "filterPref1"),
+            mock(NotificationFilterPreference.class, "filterPref2"),
+            mock(NotificationFilterPreference.class, "filterPref3")
+        );
+        when(query.execute()).thenReturn(expectedList);
+        assertEquals(expectedList, this.queryHelper.getFilterPreferences(ldQuery, owner, wikiReference));
+        verify(query).bindValue("owner", owner);
+        verify(query).setWiki(wikiName);
+
+=====================================================================
+Found a 12 line (136 tokens) duplication in the following files: 
+Starting at line 591 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+Starting at line 612 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+
+        cleanDocument.setChangeTracked(true);
+
+        assertTrue(cleanDocument.isCached());
+        assertTrue(cleanDocument.isChangeTracked());
+        assertFalse(cleanDocument.isContentDirty());
+        assertFalse(cleanDocument.isMetaDataDirty());
+        assertFalse(cleanDocument.getAttachment("filename.ext").isMetaDataDirty());
+        assertFalse(cleanDocument.getXClass().isDirty());
+        assertSame(cleanDocument, cleanDocument.getXClass().getOwnerDocument());
+        assertEquals(cleanDocument.getDocumentReference(), cleanDocument.getXClass().getDocumentReference());
+        assertFalse(((PropertyClass) cleanDocument.getXClass().getField("string")).isDirty());
+        assertSame(cleanDocument, ((PropertyClass) cleanDocument.getXClass().getField("string")).getOwnerDocument());
+
+=====================================================================
+Found a 23 line (136 tokens) duplication in the following files: 
+Starting at line 165 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/EditFormTest.java
+Starting at line 201 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/EditFormTest.java
+
+        when(this.httpRequest.getParameterValues("addedObjects")).thenReturn(new String[] {
+            "XWiki.XWikiRights_42",
+            "XWiki.XWikiRights_02",
+            "XWiki.XWikiRights_foo",
+            "",
+            "MyClass_18_param.WebHome_0_Something_18",
+            "EditIT.saveActionValidatesWhenXValidateIsPresent.WebHome_0",
+            "XWiki.MyClass_1",
+            "XWiki.XWikiRights_23",
+            "AnotherClass_010",
+            "foo_18_22",
+            "_29",
+            "A class.With Some spaces_42"
+        });
+        this.editForm.readRequest();
+
+        Map<String, List<Integer>> expectedMap = new HashMap<>();
+        expectedMap.put("XWiki.XWikiRights", Arrays.asList(42, 2, 23));
+        expectedMap.put("XWiki.MyClass", Collections.singletonList(1));
+        expectedMap.put("MyClass_18_param.WebHome_0_Something", Collections.singletonList(18));
+        expectedMap.put("EditIT.saveActionValidatesWhenXValidateIsPresent.WebHome", Collections.singletonList(0));
+        expectedMap.put("A class.With Some spaces", Collections.singletonList(42));
+        assertEquals(expectedMap, this.editForm.getObjectsToAdd());
+
+=====================================================================
+Found a 14 line (136 tokens) duplication in the following files: 
+Starting at line 111 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+Starting at line 135 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+
+                new EntityReference("wiki", EntityType.WIKI))));
+        AttachmentReference newReference =
+            new AttachmentReference("file2.txt", new DocumentReference("wiki", "space", "page"));
+        when(this.entityReferenceResolver.resolve(resourceReference, null, newReference)).thenReturn(newReference);
+        when(this.entityReferenceResolver.resolve(resourceReference, null, oldReference)).thenReturn(oldReference);
+        when(this.relativeEntityReferenceResolver.resolve(resourceReference, null, null)).thenReturn(relativeReference);
+        when(this.compactEntityReferenceSerializer.serialize(oldReference, newReference)).thenReturn("file2.txt");
+
+        assertTrue(this.renamer.updateResourceReference(resourceReference,
+            oldReference,
+            newReference,
+            new DocumentReference("xwiki", "Space", "Page"), true, Map.of()));
+
+        verify(this.defaultEntityReferenceSerializer).serialize(oldReference, newReference);
+
+=====================================================================
+Found a 15 line (136 tokens) duplication in the following files: 
+Starting at line 141 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultObjectRequiredRightAnalyzerTest.java
+Starting at line 176 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultObjectRequiredRightAnalyzerTest.java
+
+        testObject.setLargeStringValue(velocityWikiFieldName, velocityWikiContent);
+
+        XDOM wikiXDOM = new XDOM(List.of());
+        when(this.contentParser.parse(wikiContent, testSyntax, testObject.getDocumentReference())).thenReturn(wikiXDOM);
+
+        RequiredRightAnalysisResult wikiResult = mock();
+        when(this.xdomRequiredRightAnalyzer.analyze(wikiXDOM)).thenReturn(List.of(wikiResult));
+
+        List<RequiredRightAnalysisResult> results = this.analyzer.analyze(testObject);
+        verify(this.xdomRequiredRightAnalyzer).analyze(wikiXDOM);
+        verifyNoMoreInteractions(this.xdomRequiredRightAnalyzer);
+        assertEquals(testObject.getField(wikiFieldName).getReference(),
+            wikiXDOM.getMetaData().getMetaData().get(XDOMRequiredRightAnalyzer.ENTITY_REFERENCE_METADATA));
+
+        assertEquals(wikiResult, results.get(0));
+
+=====================================================================
+Found a 10 line (135 tokens) duplication in the following files: 
+Starting at line 264 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/ConfigurableClassIT.java
+Starting at line 343 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/ConfigurableClassIT.java
+
+        FormContainerElement formContainerElement = asp.getFormContainerElementForClass(fullName);
+        assertEquals(String.format("%ssave/%s", setup.getBaseBinURL(), fullName.replace('.', '/')),
+            formContainerElement.getFormAction());
+        assertEquals(setup.getDriver().getCurrentUrl(),
+            formContainerElement.getFieldValue(By.name("xredirect")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_String")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_Boolean")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_TextArea")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_Select")));
+        assertTrue(formContainerElement.hasField(By.id(fullName + "_redirect")));
+
+=====================================================================
+Found a 10 line (135 tokens) duplication in the following files: 
+Starting at line 288 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/ConfigurableClassIT.java
+Starting at line 343 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/ConfigurableClassIT.java
+
+        formContainerElement = asp.getFormContainerElementForClass(fullName);
+        assertEquals(String.format("%ssave/%s", setup.getBaseBinURL(), fullName.replace('.', '/')),
+            formContainerElement.getFormAction());
+        assertEquals(setup.getDriver().getCurrentUrl(),
+            formContainerElement.getFieldValue(By.name("xredirect")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_String")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_Boolean")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_TextArea")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_Select")));
+        assertTrue(formContainerElement.hasField(By.id(fullName + "_redirect")));
+
+=====================================================================
+Found a 49 line (135 tokens) duplication in the following files: 
+Starting at line 244 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-default/src/main/java/org/xwiki/mail/script/DeprecatedMailSenderScriptService.java
+Starting at line 244 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/MailSenderScriptService.java
+
+        return scriptMailResult;
+    }
+
+    /**
+     * Send the mail asynchronously.
+     *
+     * @param messages the list of messages that was tried to be sent
+     * @param hint the component hint of a {@link org.xwiki.mail.MailListener} component
+     * @return the result and status of the send batch
+     */
+    public ScriptMailResult sendAsynchronously(Iterable<? extends MimeMessage> messages, String hint)
+    {
+        final MailListener listener;
+        try {
+            listener = getListener(hint);
+        } catch (MessagingException e) {
+            // Save the exception for reporting through the script services's getLastError() API
+            setError(e);
+            // Don't send the mail!
+            return null;
+        }
+        return sendAsynchronously(messages, listener, true);
+    }
+
+    private MailListener getListener(String hint) throws MessagingException
+    {
+        MailListener listener;
+        try {
+            listener = this.componentManagerProvider.get().getInstance(MailListener.class, hint);
+        } catch (ComponentLookupException e) {
+            throw new MessagingException(String.format("Failed to locate [%s] Event listener. ", hint), e);
+        }
+        return listener;
+    }
+
+    /**
+     * @return the configuration for sending mails (SMTP host, port, etc)
+     */
+    public MailSenderConfiguration getConfiguration()
+    {
+        return this.senderConfiguration;
+    }
+
+    @Override
+    protected String getErrorKey()
+    {
+        return ERROR_KEY;
+    }
+}
+
+=====================================================================
+Found a 14 line (135 tokens) duplication in the following files: 
+Starting at line 373 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 398 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+    public void testVerifyMultipleObjectsPropertyNotChanged() throws XWikiException
+    {
+        XWikiDocument newDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+        XWikiDocument oldDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+
+        BaseObject newObj1 = newDoc.newObject(this.testClassName, this.context);
+        newObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject newObj2 = newDoc.newObject(this.testClassName, this.context);
+        newObj2.setStringValue(this.testPropertyName, "value2");
+
+        BaseObject oldObj1 = oldDoc.newObject(this.testClassName, this.context);
+        oldObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject oldObj2 = oldDoc.newObject(this.testClassName, this.context);
+        oldObj2.setStringValue(this.testPropertyName, "value2");
+
+=====================================================================
+Found a 13 line (135 tokens) duplication in the following files: 
+Starting at line 144 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R160100000XWIKI21738DataMigrationTest.java
+Starting at line 291 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R160100000XWIKI21738DataMigrationTest.java
+
+            .thenReturn(query3);
+
+        QueryParameter queryParameter1 = mock(QueryParameter.class, "queryParam1");
+        when(query1.bindValue("ownerLike")).thenReturn(queryParameter1);
+        when(queryParameter1.literal(any())).thenReturn(queryParameter1);
+        when(queryParameter1.anyChars()).thenReturn(queryParameter1);
+        when(queryParameter1.query()).thenReturn(query1);
+
+        QueryParameter queryParameter2 = mock(QueryParameter.class, "queryParam2");
+        when(query2.bindValue("ownerLike")).thenReturn(queryParameter2);
+        when(queryParameter2.literal(any())).thenReturn(queryParameter2);
+        when(queryParameter2.anyChars()).thenReturn(queryParameter2);
+        when(queryParameter2.query()).thenReturn(query2);
+
+=====================================================================
+Found a 12 line (135 tokens) duplication in the following files: 
+Starting at line 219 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+Starting at line 281 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+
+        verify(this.criteriaQueryLong).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(3, predicates.size());
+
+        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(2);
+        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
+        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        assertEquals("mocked date", datePredicate.getExpression().toString());
+        assertEquals(new Date(1000L), dateLowerExpression.getLiteral());
+        assertEquals(new Date(2000L), dateUpperExpression.getLiteral());
+    }
+
+=====================================================================
+Found a 26 line (135 tokens) duplication in the following files: 
+Starting at line 1047 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1085 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1122 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+
+        // Mock 1 existing template provider
+        mockExistingTemplateProviders(templateProviderFullName,
+            new DocumentReference("xwiki", Arrays.asList("XWiki"), "MyTemplateProvider"),
+            Arrays.asList("AnythingButX"));
+
+        // Run the action
+        String result = action.render(context);
+
+        // The tests are below this line!
+
+        // Verify that the create template is rendered, so the UI is displayed for the user to see the error.
+        assertEquals("create", result);
+
+        // Check that the exception is properly set in the context for the UI to display.
+        XWikiException exception = (XWikiException) this.oldcore.getScriptContext().getAttribute("createException");
+        assertNotNull(exception);
+        assertEquals(XWikiException.ERROR_XWIKI_APP_TEMPLATE_NOT_AVAILABLE, exception.getCode());
+
+        // We should not get this far so no redirect should be done, just the template will be rendered.
+        verify(mockURLFactory, never()).createURL(any(), any(), any(), any(), any(), any(), any(XWikiContext.class));
+    }
+
+    @Test
+    void newDocumentFromURLTemplateProviderSpecifiedButNotAllowed() throws Exception
+
+=====================================================================
+Found a 18 line (135 tokens) duplication in the following files: 
+Starting at line 1182 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1515 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void newDocumentWebHomeFromURLTemplateProviderSpecifiedTerminalOverriddenFromUIToNonTerminal() throws Exception
+    {
+        // new document = xwiki:X.Y.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("X", "Y"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(true);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
+        String templateProviderFullName = "XWiki.MyTemplateProvider";
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+        when(mockRequest.getParameter("tocreate")).thenReturn("nonterminal");
+
+        // Mock 1 existing template provider
+        mockExistingTemplateProviders(templateProviderFullName,
+            new DocumentReference("xwiki", Arrays.asList("XWiki"), "MyTemplateProvider"), Collections.emptyList(),
+
+=====================================================================
+Found a 16 line (134 tokens) duplication in the following files: 
+Starting at line 194 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/renderer/AnnotationXHTMLRendererTest.java
+Starting at line 226 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/renderer/AnnotationXHTMLRendererTest.java
+
+    void getAnnotatedHTML(String docName) throws Exception
+    {
+        Parser parser = this.componentManager.getInstance(Parser.class, docFactory.getDocument(docName).getSyntax());
+        XDOM xdom = parser.parse(new StringReader(docFactory.getDocument(docName).getSource()));
+
+        // run transformations
+        TransformationManager transformationManager = this.componentManager.getInstance(TransformationManager.class);
+        TransformationContext context = new TransformationContext(xdom,
+            Syntax.valueOf(docFactory.getDocument(docName).getSyntax()));
+        context.setTargetSyntax(Syntax.ANNOTATED_XHTML_1_0);
+        transformationManager.performTransformations(xdom, context);
+
+        AnnotationPrintRenderer renderer =
+            this.componentManager.getInstance(AnnotationPrintRenderer.class, ANNOTATIONS_RENDERER_HINT);
+        WikiPrinter printer = new DefaultWikiPrinter();
+        renderer.setPrinter(printer);
+
+=====================================================================
+Found a 14 line (134 tokens) duplication in the following files: 
+Starting at line 332 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/DocumentTest.java
+Starting at line 367 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/DocumentTest.java
+
+        xdoc.getXClass().addTextField("key", "Key", 30);
+        xdoc.newXObject(xdoc.getDocumentReference(), this.oldcore.getXWikiContext());
+
+        xdoc.setContentDirty(false);
+        this.oldcore.getSpyXWiki().saveDocument(xdoc, this.oldcore.getXWikiContext());
+
+        this.oldcore.getXWikiContext().setUserReference(new DocumentReference("wiki2", "XWiki", "contextuser"));
+
+        Document document = xdoc.newDocument(this.oldcore.getXWikiContext());
+
+        assertEquals(new DocumentReference("wiki1", "XWiki", "initialauthor"), document.getAuthorReference());
+        assertEquals(new DocumentReference("wiki1", "XWiki", "initialcontentauthor"),
+            document.getContentAuthorReference());
+        assertEquals(new DocumentReference("wiki1", "XWiki", "initialcreator"), document.getCreatorReference());
+
+=====================================================================
+Found a 20 line (133 tokens) duplication in the following files: 
+Starting at line 145 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/test/java/org/xwiki/administration/ConfigurableClassPageTest.java
+Starting at line 116 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+
+        when(this.query.bindValues(any(List.class))).thenReturn(this.query);
+
+        this.authorExecutor = this.componentManager.registerMockComponent(AuthorExecutor.class, true);
+
+        // Spy Velocity Engine.
+        VelocityManager velocityManager = this.componentManager.getInstance(VelocityManager.class);
+        this.velocityEngine = velocityManager.getVelocityEngine();
+        this.velocityEngine = spy(this.velocityEngine);
+        velocityManager = spy(velocityManager);
+        this.componentManager.registerComponent(VelocityManager.class, velocityManager);
+        when(velocityManager.getVelocityEngine()).thenReturn(this.velocityEngine);
+
+        when(this.authorExecutor.call(any(), any(), any())).thenAnswer(invocation -> {
+            Callable<?> callable = invocation.getArgument(0);
+            return callable.call();
+        });
+    }
+
+    @Test
+    void escapeHeadingForError() throws Exception
+
+=====================================================================
+Found a 20 line (133 tokens) duplication in the following files: 
+Starting at line 379 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 431 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+        newObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject newObj2 = newDoc.newObject(this.testClassName, this.context);
+        newObj2.setStringValue(this.testPropertyName, "value2");
+
+        BaseObject oldObj1 = oldDoc.newObject(this.testClassName, this.context);
+        oldObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject oldObj2 = oldDoc.newObject(this.testClassName, this.context);
+        oldObj2.setStringValue(this.testPropertyName, "value2");
+
+        this.passed = false;
+        this.rule.verify(newDoc, oldDoc, this.context);
+        assertFalse("My notification should not have been called", this.passed);
+
+        // The rule should be symmetric. Do the inverse test too.
+        this.passed = false;
+        this.rule.verify(oldDoc, newDoc, this.context);
+        assertFalse("My notification should not have been called", this.passed);
+    }
+
+    public void testVerifyMultipleObjectsPropertyChanged() throws XWikiException
+
+=====================================================================
+Found a 22 line (133 tokens) duplication in the following files: 
+Starting at line 125 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/thread/PrepareMailRunnableTest.java
+Starting at line 198 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/thread/PrepareMailRunnableTest.java
+
+        MimeMessage message1 = new MimeMessage(session);
+        message1.setText("Content1");
+
+        MimeMessage message2 = new MimeMessage(session);
+        message2.setText("Content2");
+
+        String batchId1 = UUID.randomUUID().toString();
+        String batchId2 = UUID.randomUUID().toString();
+
+        ExecutionContext context1 = new ExecutionContext();
+        XWikiContext xContext1 = new XWikiContext();
+        xContext1.setWikiId("wiki1");
+        context1.setProperty(XWikiContext.EXECUTIONCONTEXT_KEY, xContext1);
+
+        ExecutionContext context2 = new ExecutionContext();
+        XWikiContext xContext2 = new XWikiContext();
+        xContext2.setWikiId("wiki2");
+        context2.setProperty(XWikiContext.EXECUTIONCONTEXT_KEY, xContext2);
+
+        MemoryMailListener listener1 = this.componentManager.getInstance(MailListener.class, "memory");
+        PrepareMailQueueItem item1 =
+            new PrepareMailQueueItem(Arrays.asList(message1), session, listener1, batchId1, context1);
+
+=====================================================================
+Found a 20 line (133 tokens) duplication in the following files: 
+Starting at line 57 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/DefaultGroupingEventStrategyTest.java
+Starting at line 254 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManagerTest.java
+
+    }
+
+    private Event createMockedEvent(String type, DocumentReference user, DocumentReference doc, Date date,
+        String groupId)
+    {
+        Event event = mock(Event.class);
+        when(event.getDate()).thenReturn(date);
+        when(event.getDocument()).thenReturn(doc);
+        when(event.getUser()).thenReturn(user);
+        when(event.getType()).thenReturn(type);
+        when(event.getGroupId()).thenReturn(groupId);
+
+        when(event.toString()).thenReturn(String.format("[%s] Event [%s] on document [%s] by [%s] on [%s]", groupId,
+            type, doc, user, date.toString()));
+
+        return event;
+    }
+
+    @Test
+    void groupUC1() throws NotificationException
+
+=====================================================================
+Found a 15 line (133 tokens) duplication in the following files: 
+Starting at line 83 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 146 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 211 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 263 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_HIDDEN, true, CompareType.EQUALS, true), conditions.next());
+
+=====================================================================
+Found a 15 line (133 tokens) duplication in the following files: 
+Starting at line 344 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+Starting at line 402 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+
+        when(request.getParameter("objectPolicy")).thenReturn("updateOrCreate");
+        when(request.getParameterMap()).thenReturn(parameters);
+        when(documentReferenceResolverString.resolve("space.page")).thenReturn(this.document.getDocumentReference());
+        when(documentReferenceResolverString.resolve("InvalidSpace.InvalidPage"))
+            .thenReturn(new DocumentReference("wiki", "InvalidSpace", "InvalidPage"));
+        // This entity resolver with this 'resolve' method is used in
+        // <BaseCollection>.getXClassReference()
+        when(documentReferenceResolverEntity.resolve(any(EntityReference.class), any(DocumentReference.class)))
+            .thenReturn(this.document.getDocumentReference());
+        doReturn(this.document).when(this.oldcore.getSpyXWiki()).getDocument(this.document.getDocumentReference(),
+            context);
+
+        eform.setRequest(request);
+        eform.readRequest();
+        this.document.readObjectsFromFormUpdateOrCreate(eform, context);
+
+=====================================================================
+Found a 12 line (132 tokens) duplication in the following files: 
+Starting at line 192 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/pinned/PinnedChildPagesManagerTest.java
+Starting at line 226 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/pinned/PinnedChildPagesManagerTest.java
+
+            new DocumentReference("xwiki", List.of("Some", "S%u/b"), "WebHome"),
+            new DocumentReference("foo", "Test", "Page1")
+        );
+        DocumentReference storageReference = new DocumentReference("xwiki", "Some", "WebPreferences");
+        when(this.xwiki.getDocument(storageReference, this.xcontext)).thenReturn(this.storageDocument);
+        when(this.storageDocument.clone()).thenReturn(this.storageDocument);
+        when(this.storageDocument.isNew()).thenReturn(false);
+        DocumentAuthors documentAuthors = mock(DocumentAuthors.class);
+        when(this.storageDocument.getAuthors()).thenReturn(documentAuthors);
+
+        UserReference userReference = mock(UserReference.class);
+        when(this.currentUserReferenceResolver.resolve(CurrentUserReference.INSTANCE)).thenReturn(userReference);
+
+=====================================================================
+Found a 20 line (132 tokens) duplication in the following files: 
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-test/xwiki-platform-mentions-test-docker/src/test/it/org/xwiki/mentions/test/ui/MentionsIT.java
+Starting at line 177 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-test/xwiki-platform-mentions-test-docker/src/test/it/org/xwiki/mentions/test/ui/MentionsIT.java
+
+                pageName);
+        });
+
+        runAsUser(setup, U2_USERNAME, USERS_PWD, () -> {
+            setup.gotoPage("Main", "WebHome");
+            waitOnNotificationCount("xwiki:XWiki.U2", "xwiki", 1);
+            // check that a notif is well received
+            NotificationsTrayPage tray = new NotificationsTrayPage();
+            tray.showNotificationTray();
+            assertEquals(1, tray.getNotificationsCount());
+            assertEquals(1, tray.getUnreadNotificationsCount());
+            assertEquals("mentions.mention", tray.getNotificationType(0));
+            String notificationContent = tray.getNotificationContent(0);
+            String expected = "You have received one mention.";
+            assertTrue(notificationContent.contains(expected),
+                String.format("Notification content should contain [%s] but is [%s].", expected, notificationContent));
+            final WebElement rootElement = tray.getNotificationsButton();
+            MentionNotificationPage mentionNotificationPage = new MentionNotificationPage(rootElement);
+            mentionNotificationPage.openGroup(0);
+            assertEquals("mentioned you on page Mention Test Page", mentionNotificationPage.getText(0, 0));
+
+=====================================================================
+Found a 16 line (132 tokens) duplication in the following files: 
+Starting at line 306 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 386 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 426 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filters = Collections.singleton(notificationFilter1);
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new InQueryCondition(true, Event.FIELD_ID, Arrays.asList("event1", "event2")), conditions.next());
+
+=====================================================================
+Found a 14 line (132 tokens) duplication in the following files: 
+Starting at line 263 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPluginTest.java
+Starting at line 157 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPluginTest.java
+
+        String className = CssSkinExtensionPlugin.class.getCanonicalName();
+        Set<String> resources = (Set<String>) context.get(className);
+
+        assertEquals(Collections.singleton(resource), resources);
+
+        Map<String, Map<String, Object>> parametersMap =
+            (Map<String, Map<String, Object>>) context.get(className + "_parameters");
+        Map<String, Map<String, Object>> expectedParameters = new HashMap<>();
+        expectedParameters.put(resource, parameters);
+
+        assertEquals(expectedParameters, parametersMap);
+        verify(this.authorizationManager)
+            .hasAccess(Right.SCRIPT, EntityType.DOCUMENT, userReference, documentReference);
+        verify(this.skinExtensionAsync).use("ssx", resource, parameters);
+
+=====================================================================
+Found a 22 line (131 tokens) duplication in the following files: 
+Starting at line 105 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/listeners/ColorThemeListenerTest.java
+Starting at line 133 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/listeners/ColorThemeListenerTest.java
+
+        EntityReference classReference = new LocalDocumentReference("FlamingoThemesCode", "ThemeClass");
+        List<BaseObject> objects = new ArrayList<>();
+        BaseObject object = mock(BaseObject.class);
+        objects.add(object);
+        when(doc.getXObjects(classReference)).thenReturn(objects);
+
+        DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
+        when(doc.getDocumentReference()).thenReturn(documentReference);
+
+        ColorThemeReference colorThemeReference = new DocumentColorThemeReference(documentReference, null);
+        when(colorThemeReferenceFactory.createReference(eq(documentReference))).thenReturn(colorThemeReference);
+
+        // Test
+        mocker.getComponentUnderTest().onEvent(event, doc, data);
+
+        // Verify
+        verify(lessResourcesCache).clearFromColorTheme(colorThemeReference);
+        verify(colorThemeCache).clearFromColorTheme(colorThemeReference);
+    }
+
+    @Test
+    public void onEventWhenColorThemeChanged() throws Exception
+
+=====================================================================
+Found a 9 line (131 tokens) duplication in the following files: 
+Starting at line 65 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/PackageTest.java
+Starting at line 91 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/PackageTest.java
+
+        this.pack.Import(this.createZipFile(docs, new String[] { "ISO-8859-1", "UTF-8" }, null),
+            this.oldcore.getXWikiContext());
+
+        assertEquals(2, this.pack.getFiles().size());
+        assertEquals(this.pack.getFiles().get(0).getDoc().getTitle(),
+            (this.pack.getFiles().get(1)).getDoc().getTitle());
+        assertEquals(this.pack.getFiles().get(0).getDoc().getContent(),
+            this.pack.getFiles().get(1).getDoc().getContent());
+    }
+
+=====================================================================
+Found a 16 line (131 tokens) duplication in the following files: 
+Starting at line 174 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiCacheStoreTest.java
+Starting at line 229 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiCacheStoreTest.java
+
+    void documentSavedDuringLoadIsVisibleInNextLoad() throws Exception
+    {
+        // Save a document
+        this.oldcore.getXWikiContext().setWikiId("wiki");
+        XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
+        XWikiDocument initialDocument = document.clone();
+
+        XWikiStoreInterface hibernateStore = this.oldcore.getMockStore();
+        XWikiCacheStore store = new XWikiCacheStore(hibernateStore, this.oldcore.getXWikiContext());
+        CompletableFuture<XWikiDocument> arrivedLoadFuture = new CompletableFuture<>();
+        CompletableFuture<XWikiDocument> storeLoadFuture = new CompletableFuture<>();
+
+        when(hibernateStore.loadXWikiDoc(any(), any())).then(invocation -> {
+            arrivedLoadFuture.complete(document);
+            return storeLoadFuture.get(10, TimeUnit.SECONDS);
+        });
+
+=====================================================================
+Found a 14 line (131 tokens) duplication in the following files: 
+Starting at line 190 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/web/PageTemplateRequiredRightsCheckerTest.java
+Starting at line 233 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/web/PageTemplateRequiredRightsCheckerTest.java
+
+    void hasRequiredRightsWithMultipleRightsAllGranted() throws Exception
+    {
+        DocumentRequiredRights requiredRights = new DocumentRequiredRights(true, new LinkedHashSet<>(List.of(
+            new DocumentRequiredRight(Right.SCRIPT, EntityType.DOCUMENT),
+            new DocumentRequiredRight(Right.EDIT, EntityType.SPACE),
+            new DocumentRequiredRight(Right.ADMIN, EntityType.WIKI)
+        )));
+        when(this.documentRequiredRightsManager.getRequiredRights(TEMPLATE_REFERENCE))
+            .thenReturn(Optional.of(requiredRights));
+        when(this.authorizationManager.hasAccess(Right.SCRIPT, USER_REFERENCE, TARGET_DOCUMENT_REFERENCE))
+            .thenReturn(true);
+        SpaceReference lastSpaceReference = TARGET_DOCUMENT_REFERENCE.getLastSpaceReference();
+        when(this.authorizationManager.hasAccess(Right.EDIT, USER_REFERENCE, lastSpaceReference))
+            .thenReturn(true);
+
+=====================================================================
+Found a 24 line (131 tokens) duplication in the following files: 
+Starting at line 512 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/DefaultWikiUserManager.java
+Starting at line 549 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/DefaultWikiUserManager.java
+
+        request.setStatus(MemberCandidacy.Status.ACCEPTED);
+        request.setDateOfClosure(new Date());
+
+        // Get the group document
+        XWikiDocument groupDoc = getMembersGroupDocument(request.getWikiId());
+
+        // Avoid modifying the cached document
+        groupDoc = groupDoc.clone();
+
+        // Get the candidacy object
+        BaseObject object = groupDoc.getXObject(WikiCandidateMemberClassInitializer.REFERENCE, request.getId());
+
+        // Set the new values
+        object.setStringValue(WikiCandidateMemberClassInitializer.FIELD_ADMIN, request.getAdminId());
+        object.setLargeStringValue(WikiCandidateMemberClassInitializer.FIELD_ADMIN_COMMENT, request.getAdminComment());
+        object.setLargeStringValue(WikiCandidateMemberClassInitializer.FIELD_ADMIN_PRIVATE_COMMENT,
+                request.getAdminPrivateComment());
+        object.setDateValue(WikiCandidateMemberClassInitializer.FIELD_DATE_OF_CLOSURE,
+                request.getDateOfClosure());
+        object.setStringValue(WikiCandidateMemberClassInitializer.FIELD_STATUS,
+                request.getStatus().name().toLowerCase());
+
+        // Save the document
+        saveGroupDocument(groupDoc, String.format("Accept join request from user [%s]", request.getUserId()));
+
+=====================================================================
+Found a 13 line (130 tokens) duplication in the following files: 
+Starting at line 294 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+Starting at line 319 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+Starting at line 345 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+
+        verify(query).bindValue(BIND_STORE, FULLNAME);
+
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_KEYID), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_ISSUER), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SERIAL), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SUBJECT), any(String.class));
+        verify(certObj).setLargeStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_CERTIFICATE, ENCODED_CERTIFICATE);
+
+        verify(xwiki).saveDocument(storeDoc, xcontext);
+    }
+
+    @Test
+    public void testUpdatingCertificateWithKeyIdToSpace() throws Exception
+
+=====================================================================
+Found a 14 line (130 tokens) duplication in the following files: 
+Starting at line 50 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/minor/MinorEventAlertNotificationFilterTest.java
+Starting at line 85 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/minor/MinorEventEmailNotificationFilterTest.java
+
+    @Test
+    void filterEvent()
+    {
+        DocumentReference randomUser = new DocumentReference("xwiki", "XWiki", "UserA");
+        Event event1 = mock(Event.class);
+        Event event2 = mock(Event.class);
+        Event event3 = mock(Event.class);
+        when(event1.getType()).thenReturn("update");
+        when(event1.getDocumentVersion()).thenReturn("2.12");
+        when(event2.getType()).thenReturn("addComment");
+        when(event2.getDocumentVersion()).thenReturn("2.12");
+        when(event3.getType()).thenReturn("update");
+        when(event3.getDocumentVersion()).thenReturn("2.1");
+        assertEquals(NotificationFilter.FilterPolicy.FILTER,
+
+=====================================================================
+Found a 16 line (130 tokens) duplication in the following files: 
+Starting at line 262 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 306 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 386 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 426 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 513 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filters = Arrays.asList(notificationFilter1, notificationFilter2);
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_DOCUMENT, "someValue1", CompareType.EQUALS, false),
+
+=====================================================================
+Found a 30 line (130 tokens) duplication in the following files: 
+Starting at line 68 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35100XWIKI7564DataMigration.java
+Starting at line 70 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35102XWIKI7771DataMigration.java
+
+        return new XWikiDBVersion(35100);
+    }
+
+    @Override
+    public boolean shouldExecute(XWikiDBVersion startupVersion)
+    {
+        boolean shouldExecute = false;
+        try {
+            getStore().beginTransaction(getXWikiContext());
+            // Run this migration if the database isn't new
+            shouldExecute = (startupVersion.getVersion() > 0
+                && getStore().getDatabaseProductName() == DatabaseProduct.POSTGRESQL);
+            getStore().endTransaction(getXWikiContext(), false);
+        } catch (XWikiException ex) {
+            // Shouldn't happen, ignore
+        } catch (DataMigrationException ex) {
+            // Shouldn't happen, ignore
+        }
+        return shouldExecute;
+    }
+
+    @Override
+    public void hibernateMigrate() throws DataMigrationException, XWikiException
+    {
+        getStore().executeWrite(getXWikiContext(), new HibernateCallback<Object>()
+        {
+            @Override
+            public Object doInHibernate(Session session) throws HibernateException, XWikiException
+            {
+                session.doWork(new R35100Work());
+
+=====================================================================
+Found a 21 line (130 tokens) duplication in the following files: 
+Starting at line 164 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+Starting at line 125 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManagerTest.java
+
+        when(this.documentAccessBridge.exists(any(DocumentReference.class))).thenReturn(true);
+    }
+
+    private QueryResponse prepareSolrClientQueryWhenStatement(SolrClient solrClient, SolrQuery expectedQuery)
+        throws Exception
+    {
+        QueryResponse response = mock(QueryResponse.class);
+        when(solrClient.query(any())).then(invocationOnMock -> {
+            SolrQuery givenQuery = invocationOnMock.getArgument(0);
+            assertEquals(expectedQuery.getQuery(), givenQuery.getQuery());
+            assertArrayEquals(expectedQuery.getFilterQueries(), givenQuery.getFilterQueries());
+            assertEquals(expectedQuery.getRows(), givenQuery.getRows());
+            assertEquals(expectedQuery.getStart(), givenQuery.getStart());
+            assertEquals(expectedQuery.getSorts(), givenQuery.getSorts());
+            return response;
+        });
+        return response;
+    }
+
+    @Test
+    void countRatings() throws Exception
+
+=====================================================================
+Found a 17 line (129 tokens) duplication in the following files: 
+Starting at line 280 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 386 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        setFilter("category", "Information");
+        this.request.put("category/join_mode", "OR");
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+
+        renderPage();
+
+        verify(this.queryService)
+            .hql(", BaseObject as obj , StringProperty as prop_category, StringProperty prop_name  "
+                + "where obj.name=doc.fullName and obj.className = :className "
+                + "and doc.fullName not in (:classTemplate1, :classTemplate2)  "
+                + "and obj.id = prop_category.id.id and prop_category.id.name = :prop_category_id_name "
+                + "and ((prop_category.value like :prop_category_value_1 or prop_category.value is null) "
+
+=====================================================================
+Found a 30 line (129 tokens) duplication in the following files: 
+Starting at line 193 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/integration/JavaIntegrationTest.java
+Starting at line 172 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/integration/ScriptingIntegrationTest.java
+
+        when(execution.getContext()).thenReturn(executionContext);
+
+        Copier<ExecutionContext> executionContextCloner =
+            this.componentManager.getInstance(new DefaultParameterizedType(null, Copier.class, ExecutionContext.class));
+        // Just return the same execution context
+        when(executionContextCloner.copy(executionContext)).thenReturn(executionContext);
+
+        // Simulate receiving the Application Ready Event to start the mail threads
+        MailSenderInitializerListener listener =
+            this.componentManager.getInstance(EventListener.class, MailSenderInitializerListener.LISTENER_NAME);
+        listener.onEvent(new ApplicationReadyEvent(), null, null);
+    }
+
+    @AfterEach
+    public void cleanUp() throws Exception
+    {
+        logCapture.ignoreAllMessages();
+
+        // Make sure we stop the Mail Sender thread after each test (since it's started automatically when looking
+        // up the MailSender component.
+        Disposable listener =
+            this.componentManager.getInstance(EventListener.class, MailSenderInitializerListener.LISTENER_NAME);
+        listener.dispose();
+
+        this.greenMail.stop();
+    }
+
+    @Test
+    public void sendTextMail() throws Exception
+    {
+
+=====================================================================
+Found a 15 line (129 tokens) duplication in the following files: 
+Starting at line 83 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 307 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 387 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 427 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 514 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_HIDDEN, true, CompareType.EQUALS, true), conditions.next());
+
+=====================================================================
+Found a 11 line (129 tokens) duplication in the following files: 
+Starting at line 193 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/attachments/AttachmentsResourceImplTest.java
+Starting at line 224 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/attachments/AttachmentsResourceImplTest.java
+
+        DocumentReference documentReference = new DocumentReference("test", Arrays.asList("Path", "To"), "Page");
+        XWikiDocument cachedDocument = prepareXWikiDocument(documentReference, "test:Path.To.Page", true, true, false);
+
+        AttachmentReference attachmentReference = new AttachmentReference("myBio.txt", documentReference);
+        when(this.currentGetDocumentReferenceResolver.resolve(attachmentReference)).thenReturn(documentReference);
+
+        mockRequest("bio.txt", "myBio.txt", "blah", "text/plain");
+
+        Attachment attachment = mock(Attachment.class);
+        when(this.modelFactory.toRestAttachment(eq(this.uriInfo.getBaseUri()), any(com.xpn.xwiki.api.Attachment.class),
+            eq(false), eq(false))).thenReturn(attachment);
+
+=====================================================================
+Found a 16 line (129 tokens) duplication in the following files: 
+Starting at line 581 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/PageResourceIT.java
+Starting at line 606 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/PageResourceIT.java
+
+    public void testPOSTPageFormUrlEncoded() throws Exception
+    {
+        final String CONTENT = String.format("This is a content (%d)", System.currentTimeMillis());
+        final String TITLE = String.format("Title (%s)", UUID.randomUUID());
+
+        Page originalPage = getFirstPage();
+
+        Link link = getFirstLinkByRelation(originalPage, Relations.SELF);
+        Assert.assertNotNull(link);
+
+        NameValuePair[] nameValuePairs = new NameValuePair[2];
+        nameValuePairs[0] = new NameValuePair("title", TITLE);
+        nameValuePairs[1] = new NameValuePair("content", CONTENT);
+
+        PostMethod postMethod = executePostForm(String.format("%s?method=PUT", link.getHref()), nameValuePairs,
+            TestUtils.SUPER_ADMIN_CREDENTIALS.getUserName(), TestUtils.SUPER_ADMIN_CREDENTIALS.getPassword());
+
+=====================================================================
+Found a 29 line (128 tokens) duplication in the following files: 
+Starting at line 153 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/AbstractURLResourceTranslationBundle.java
+Starting at line 192 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/main/java/org/xwiki/localization/wiki/internal/AbstractDocumentTranslationBundle.java
+
+        DefaultLocalizedTranslationBundle localeBundle = new DefaultLocalizedTranslationBundle(this, locale);
+
+        TranslationMessageParser parser = getTranslationMessageParser();
+
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
+                String key = (String) entry.getKey();
+                String message = (String) entry.getValue();
+
+                TranslationMessage translationMessage = parser.parse(message);
+
+                localeBundle.addTranslation(new DefaultTranslation(this.bundleContext, localeBundle, key,
+                    translationMessage));
+            }
+        }
+
+        return localeBundle;
+    }
+
+    /**
+     * @return the parser to use
+     */
+    protected TranslationMessageParser getTranslationMessageParser()
+    {
+        return this.translationMessageParser;
+    }
+
+    @Override
+    protected LocalizedTranslationBundle createBundle(Locale locale)
+
+=====================================================================
+Found a 15 line (128 tokens) duplication in the following files: 
+Starting at line 170 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+Starting at line 511 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+
+        object = (Object) unmarshaller.unmarshal(postMethod.getResponseBodyAsStream());
+
+        Assert.assertEquals(TAG_VALUE, getProperty(object, "tags").getValue());
+
+        GetMethod getMethod = executeGet(buildURI(ObjectResource.class, getWiki(), this.spaces, this.pageName,
+            object.getClassName(), object.getNumber()).toString());
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        object = (Object) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+
+        Assert.assertEquals(TAG_VALUE, getProperty(object, "tags").getValue());
+    }
+
+    @Test
+    public void testPOSTInvalidObject() throws Exception
+
+=====================================================================
+Found a 6 line (127 tokens) duplication in the following files: 
+Starting at line 425 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
+Starting at line 444 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
+
+        assertSame(status11, this.store.events.get(event1.getId()).mailstatuses.get(status11.getEntityId()));
+        assertSame(status13, this.store.events.get(event1.getId()).mailstatuses.get(status13.getEntityId()));
+        assertSame(status21, this.store.events.get(event2.getId()).mailstatuses.get(status21.getEntityId()));
+        assertSame(status24, this.store.events.get(event2.getId()).mailstatuses.get(status24.getEntityId()));
+
+        verify(this.observation).notify(any(EventStreamAddedEvent.class), eq(event1));
+
+=====================================================================
+Found a 6 line (126 tokens) duplication in the following files: 
+Starting at line 140 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/test/java/org/xwiki/administration/ConfigurableClassPageTest.java
+Starting at line 222 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetdocumentsPageTest.java
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.addFilter(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.bindValues(any(List.class))).thenReturn(this.query);
+
+=====================================================================
+Found a 10 line (126 tokens) duplication in the following files: 
+Starting at line 294 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+Starting at line 372 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+
+        verify(query).bindValue(BIND_STORE, FULLNAME);
+
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_KEYID), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_ISSUER), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SERIAL), any(String.class));
+        verify(certObj, never()).setStringValue(eq(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SUBJECT), any(String.class));
+        verify(certObj).setLargeStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_CERTIFICATE, ENCODED_CERTIFICATE);
+
+        verify(xwiki).saveDocument(storeDoc, xcontext);
+    }
+
+=====================================================================
+Found a 34 line (126 tokens) duplication in the following files: 
+Starting at line 47 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/internal/safe/SafeAdvancedSearchableExtensionRepository.java
+Starting at line 47 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/internal/safe/SafeAdvancedSearchableRatableExtensionRepository.java
+
+    public SafeAdvancedSearchableExtensionRepository(T repository, ScriptSafeProvider<?> safeProvider,
+        Execution execution, boolean hasProgrammingRight)
+    {
+        super(repository, safeProvider, execution, hasProgrammingRight);
+    }
+
+    // AdvancedSearchable
+
+    @Override
+    public boolean isFilterable()
+    {
+        return ((AdvancedSearchable) getWrapped()).isFilterable();
+    }
+
+    @Override
+    public boolean isSortable()
+    {
+        return ((AdvancedSearchable) getWrapped()).isSortable();
+    }
+
+    @Override
+    public IterableResult<Extension> search(ExtensionQuery query) throws SearchException
+    {
+        setError(null);
+
+        try {
+            return safe(((AdvancedSearchable) getWrapped()).search(query));
+        } catch (Exception e) {
+            setError(e);
+        }
+
+        return null;
+    }
+}
+
+=====================================================================
+Found a 17 line (126 tokens) duplication in the following files: 
+Starting at line 195 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+Starting at line 340 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+
+    void watchWhenNoFilterMatch() throws Exception
+    {
+        // Mocks
+        WatchedEntityReference watchedEntityReference = mock(WatchedEntityReference.class);
+        DocumentReference userDocRef = new DocumentReference("xwiki", "XWiki", "User");
+        UserReference userRef = mock(UserReference.class);
+        when(this.userReferenceResolver.resolve(userDocRef)).thenReturn(userRef);
+        when(this.userReferenceSerializer.serialize(userRef)).thenReturn(userDocRef);
+
+        // Filters
+        DefaultNotificationFilterPreference pref1 = new DefaultNotificationFilterPreference();
+        pref1.setNotificationFormats(Sets.newSet(NotificationFormat.ALERT, NotificationFormat.EMAIL));
+
+        when(notificationFilterPreferenceManager.getFilterPreferences(userDocRef)).thenReturn(Sets.newSet(pref1));
+
+        when(watchedEntityReference.getWatchedStatus(userRef))
+            .thenReturn(WatchedEntityReference.WatchedStatus.NOT_SET);
+
+=====================================================================
+Found a 14 line (126 tokens) duplication in the following files: 
+Starting at line 115 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 146 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 263 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 307 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 387 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 427 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 514 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+
+=====================================================================
+Found a 16 line (126 tokens) duplication in the following files: 
+Starting at line 957 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1363 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1402 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1440 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void existingDocumentFromUITemplateProviderSpecifiedRestrictionExists() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
+        String templateProviderFullName = "XWiki.MyTemplateProvider";
+        String spaceReferenceString = "X";
+        when(mockRequest.getParameter("spaceReference")).thenReturn(spaceReferenceString);
+        when(mockRequest.getParameter("name")).thenReturn("Y");
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+
+=====================================================================
+Found a 12 line (126 tokens) duplication in the following files: 
+Starting at line 295 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+Starting at line 324 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+
+    void createRedirectOnNewDocument() throws Exception
+    {
+        DocumentReference oldReference = new DocumentReference("wiki", "Space", "Old");
+        DocumentReference newReference = new DocumentReference("wiki", "Space", "New");
+
+        XWikiDocument oldDocument = mock(XWikiDocument.class);
+        when(oldDocument.clone()).thenReturn(oldDocument);
+        when(this.xcontext.getWiki().getDocument(oldReference, this.xcontext)).thenReturn(oldDocument);
+        when(oldDocument.newXObject(RedirectClassDocumentInitializer.REFERENCE, this.xcontext))
+            .thenReturn(mock(BaseObject.class));
+        when(oldDocument.getAuthors()).thenReturn(mock());
+        when(oldDocument.isNew()).thenReturn(true);
+
+=====================================================================
+Found a 36 line (126 tokens) duplication in the following files: 
+Starting at line 58 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/AttachmentsResourceIT.java
+Starting at line 46 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/CommentsResourceIT.java
+
+public class AttachmentsResourceIT extends AbstractHttpIT
+{
+    private String wikiName;
+
+    private List<String> spaces;
+
+    private String pageName;
+
+    private DocumentReference reference;
+
+    @Before
+    @Override
+    public void setUp() throws Exception
+    {
+        super.setUp();
+
+        this.wikiName = getWiki();
+        this.spaces = Arrays.asList(getTestClassName());
+        this.pageName = getTestMethodName();
+
+        this.reference = new DocumentReference(this.wikiName, this.spaces, this.pageName);
+
+        // Create a clean test page.
+        this.testUtils.rest().delete(this.reference);
+        this.testUtils.rest().savePage(this.reference);
+    }
+
+    @Override
+    @Test
+    public void testRepresentation() throws Exception
+    {
+        /* Everything is done in test methods. */
+    }
+
+    @Test
+    public void testPUTGETAttachments() throws Exception
+
+=====================================================================
+Found a 17 line (125 tokens) duplication in the following files: 
+Starting at line 87 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/users/UsersMimeMessageIteratorTest.java
+Starting at line 130 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/group/GroupMimeMessageIteratorTest.java
+
+            new UsersMimeMessageIterator(userReferences, factory, parameters, componentManager);
+
+        assertTrue(iterator.hasNext());
+        MimeMessage message1 = iterator.next();
+        assertArrayEquals(message1.getRecipients(Message.RecipientType.TO), InternetAddress.parse("john@doe.com"));
+
+        assertTrue(iterator.hasNext());
+        MimeMessage message2 = iterator.next();
+        assertArrayEquals(message2.getRecipients(Message.RecipientType.TO), InternetAddress.parse("jane@doe.com"));
+
+        assertTrue(iterator.hasNext());
+        MimeMessage message3 = iterator.next();
+        assertArrayEquals(message3.getRecipients(Message.RecipientType.TO), InternetAddress.parse("jannie@doe.com"));
+
+        assertFalse(iterator.hasNext());
+    }
+}
+
+=====================================================================
+Found a 17 line (125 tokens) duplication in the following files: 
+Starting at line 56 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DownloadRevAction.java
+Starting at line 66 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ViewAttachRevAction.java
+
+        if (filename != null && context.getWiki().hasAttachmentRecycleBin(context)
+            && request.getParameter("rid") != null)
+        {
+            int recycleId = Integer.parseInt(request.getParameter("rid"));
+            attachment = new XWikiAttachment(doc, filename);
+            attachment =
+                context.getWiki().getAttachmentRecycleBinStore().restoreFromRecycleBin(attachment, recycleId, context,
+                    true);
+        } else if (request.getParameter("id") != null) {
+            int id = Integer.parseInt(request.getParameter("id"));
+            attachment = doc.getAttachmentList().get(id);
+        } else {
+            // Note: doc.getAttachment return null when the filename is null
+            attachment = doc.getAttachment(filename);
+        }
+
+        if (attachment == null) {
+
+=====================================================================
+Found a 14 line (125 tokens) duplication in the following files: 
+Starting at line 74 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/renderer/XWikiLinkLabelGeneratorTest.java
+Starting at line 100 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/renderer/XWikiLinkLabelGeneratorTest.java
+
+            new DocumentReference("wiki", Arrays.asList("space1", "space2"), "HelloWorld");
+
+        EntityReferenceResolver<ResourceReference> resourceReferenceResolver = this.mocker.getInstance(
+            new DefaultParameterizedType(null, EntityReferenceResolver.class, ResourceReference.class));
+        when(resourceReferenceResolver.resolve(resourceReference, EntityType.DOCUMENT)).thenReturn(documentReference);
+
+        DocumentAccessBridge dab = this.mocker.getInstance(DocumentAccessBridge.class);
+        DocumentModelBridge dmb = mock(DocumentModelBridge.class);
+        when(dab.getTranslatedDocumentInstance(documentReference)).thenReturn(dmb);
+        when(dmb.getTitle()).thenReturn("My title");
+
+        EntityReferenceSerializer<String> localSerializer =
+            this.mocker.getInstance(EntityReferenceSerializer.TYPE_STRING, "local");
+        when(localSerializer.serialize(new SpaceReference("wiki", "space1", "space2"))).thenReturn("space1.space2");
+
+=====================================================================
+Found a 14 line (125 tokens) duplication in the following files: 
+Starting at line 353 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+Starting at line 415 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+
+        PutMethod putMethod = executePutXml(tagsPropertyLink.getHref(), newTags,
+            TestUtils.SUPER_ADMIN_CREDENTIALS.getUserName(), TestUtils.SUPER_ADMIN_CREDENTIALS.getPassword());
+        Assert.assertEquals(getHttpMethodInfo(putMethod), HttpStatus.SC_ACCEPTED, putMethod.getStatusCode());
+
+        getMethod = executeGet(buildURI(ObjectResource.class, getWiki(), this.spaces, this.pageName,
+            currentObject.getClassName(), currentObject.getNumber()).toString());
+        Assert.assertEquals(HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        currentObject = (Object) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+
+        tagsProperty = getProperty(currentObject, "tags");
+
+        Assert.assertEquals(TAG_VALUE, tagsProperty.getValue());
+    }
+
+=====================================================================
+Found a 16 line (125 tokens) duplication in the following files: 
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetgroupmembersPageTest.java
+Starting at line 144 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetgroupmembersPageTest.java
+
+        this.request.put("limit", "10");
+        this.request.put("offset", "1");
+
+        DocumentReference groupDocumentReference = new DocumentReference("xwiki", "XWiki", "group");
+
+        XWikiDocument groupDoc = this.xwiki.getDocument(groupDocumentReference, this.context);
+        this.context.setDoc(groupDoc);
+
+        this.xwiki.createUser("U1", Collections.emptyMap(), this.context);
+        this.xwiki.createUser("U2", Collections.emptyMap(), this.context);
+
+        when(this.xwiki.getRightService().hasAccessLevel("view", "XWiki.XWikiGuest", "U2", this.context))
+            .thenAnswer(invocationOnMock -> false);
+
+        GroupCacheEntry groupCacheEntry = mock(GroupCacheEntry.class);
+        when(this.membersCache.getCacheEntry(groupDocumentReference, true)).thenReturn(groupCacheEntry);
+
+=====================================================================
+Found a 16 line (124 tokens) duplication in the following files: 
+Starting at line 97 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/thread/SendMailRunnableTest.java
+Starting at line 162 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/thread/SendMailRunnableTest.java
+
+        properties.setProperty("mail.smtp.host", "xwiki-unknown");
+        Session session = Session.getDefaultInstance(properties);
+
+        MimeMessage msg1 = new MimeMessage(session);
+        msg1.setText("Content1");
+        ExtendedMimeMessage message1 = new ExtendedMimeMessage(msg1);
+        String id1 = message1.getUniqueMessageId();
+        MimeMessage msg2 = new MimeMessage(session);
+        msg2.setText("Content2");
+        ExtendedMimeMessage message2 = new ExtendedMimeMessage(msg2);
+        String id2 = message2.getUniqueMessageId();
+
+        MemoryMailListener listener = this.componentManager.getInstance(MailListener.class, "memory");
+        String batchId = UUID.randomUUID().toString();
+        listener.onPrepareBegin(batchId, Collections.emptyMap());
+        ((UpdateableMailStatusResult) listener.getMailStatusResult()).setTotalSize(2);
+
+=====================================================================
+Found a 12 line (124 tokens) duplication in the following files: 
+Starting at line 134 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentReferenceEntityReferenceResolverTest.java
+Starting at line 150 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentStringEntityReferenceResolverTest.java
+
+            resolver.resolve(new EntityReference("filename", EntityType.ATTACHMENT), EntityType.ATTACHMENT);
+
+        assertEquals(CURRENT_DOCUMENT, reference.getParent().getName());
+        assertEquals(EntityType.DOCUMENT, reference.getParent().getType());
+        assertEquals(CURRENT_SPACE, reference.getParent().getParent().getName());
+        assertEquals(EntityType.SPACE, reference.getParent().getParent().getType());
+        assertEquals(CURRENT_WIKI, reference.getParent().getParent().getParent().getName());
+        assertEquals(EntityType.WIKI, reference.getParent().getParent().getParent().getType());
+    }
+
+    @Test
+    public void resolvePageReferenceWhenTypeIsDocument()
+
+=====================================================================
+Found a 12 line (124 tokens) duplication in the following files: 
+Starting at line 179 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultMacroRefactoringTest.java
+Starting at line 204 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultMacroRefactoringTest.java
+
+        });
+        when(this.macroContentParser.parse(eq(macroContent), any(), eq(true), eq(false)))
+            .thenAnswer(invocationOnMock -> {
+            MacroTransformationContext transformationContext = invocationOnMock.getArgument(1);
+            assertEquals(transformationContext.getId(), "refactoring_" + macroId);
+            assertEquals(macroBlock, transformationContext.getCurrentMacroBlock());
+            assertEquals(this.syntax, transformationContext.getSyntax());
+            assertFalse(transformationContext.isInline());
+            return xdom;
+        });
+        when(this.referenceRenamer.renameReferences(xdom, this.currentDocumentReference, this.sourceReference,
+            this.targetReference, true, Map.of())).thenReturn(false);
+
+=====================================================================
+Found a 11 line (123 tokens) duplication in the following files: 
+Starting at line 700 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
+Starting at line 736 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
+
+        this.eventStore.saveEventStatus(status22).get();
+
+        SolrDocument document1 = this.eventStore.getEventDocument(EVENT1.getId());
+        assertEquals(Arrays.asList("entity1"), document1.get(EventsSolrCoreInitializer.SOLR_FIELD_READLISTENERS));
+        assertEquals(Arrays.asList("entity2"), document1.get(EventsSolrCoreInitializer.SOLR_FIELD_UNREADLISTENERS));
+
+        SolrDocument document2 = this.eventStore.getEventDocument(EVENT2.getId());
+        assertEquals(Arrays.asList("entity3"), document2.get(EventsSolrCoreInitializer.SOLR_FIELD_READLISTENERS));
+        assertEquals(Arrays.asList("entity1"), document2.get(EventsSolrCoreInitializer.SOLR_FIELD_UNREADLISTENERS));
+
+        assertSearch(Arrays.asList(EVENT1, EVENT2), new SimpleEventQuery().withStatus(true));
+
+=====================================================================
+Found a 17 line (123 tokens) duplication in the following files: 
+Starting at line 115 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/configuration/GeneralMailConfigClassDocumentConfigurationSourceTest.java
+Starting at line 115 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/configuration/SendMailConfigClassDocumentConfigurationSourceTest.java
+
+        LocalDocumentReference classReference = new LocalDocumentReference("Mail", "GeneralMailConfigClass");
+
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getXObject(classReference)).thenReturn(null);
+
+        DocumentReference documentReference = new DocumentReference("wiki", "Mail", "MailConfig");
+        XWiki xwiki = mock(XWiki.class);
+        when(xwiki.getDocument(eq(documentReference), any(XWikiContext.class))).thenReturn(document);
+
+        XWikiContext xcontext = mock(XWikiContext.class);
+        when(xcontext.getWiki()).thenReturn(xwiki);
+
+        when(this.xcontextProvider.get()).thenReturn(xcontext);
+
+        assertEquals("defaultValue", this.source.getProperty("key", "defaultValue"));
+    }
+}
+
+=====================================================================
+Found a 14 line (123 tokens) duplication in the following files: 
+Starting at line 52 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitReferenceEntityReferenceResolverTest.java
+Starting at line 52 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringEntityReferenceResolverTest.java
+
+            this.resolver.resolve(null, EntityType.DOCUMENT, new DocumentReference("wiki", "space", "page"));
+
+        assertEquals("page", reference.getName());
+        assertEquals(EntityType.DOCUMENT, reference.getType());
+        assertEquals("space", reference.getParent().getName());
+        assertEquals(EntityType.SPACE, reference.getParent().getType());
+        assertEquals("wiki", reference.getParent().getParent().getName());
+        assertEquals(EntityType.WIKI, reference.getParent().getParent().getType());
+    }
+
+    @Test
+    public void resolveWithExplicitEntityReference()
+    {
+        EntityReference reference = this.resolver.resolve(new EntityReference("page", EntityType.DOCUMENT,
+
+=====================================================================
+Found a 15 line (123 tokens) duplication in the following files: 
+Starting at line 66 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitReferenceEntityReferenceResolverTest.java
+Starting at line 66 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringEntityReferenceResolverTest.java
+
+            new EntityReference("space", EntityType.SPACE)), EntityType.DOCUMENT,
+            new EntityReference("wiki", EntityType.WIKI));
+
+        assertEquals("page", reference.getName());
+        assertEquals(EntityType.DOCUMENT, reference.getType());
+        assertEquals("space", reference.getParent().getName());
+        assertEquals(EntityType.SPACE, reference.getParent().getType());
+        assertEquals("wiki", reference.getParent().getParent().getName());
+        assertEquals(EntityType.WIKI, reference.getParent().getParent().getType());
+    }
+
+    @Test
+    public void resolveWithAbsoluteReferenceAndNoExplicitReference()
+    {
+        EntityReference reference = this.resolver.resolve(new EntityReference("page", EntityType.DOCUMENT,
+
+=====================================================================
+Found a 13 line (123 tokens) duplication in the following files: 
+Starting at line 64 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentUserAndGroupDocumentReferenceResolverTest.java
+Starting at line 63 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/UserAndGroupDocumentReferenceResolverTest.java
+
+        assertEquals(new DocumentReference("currentwiki", "bossesSpace", "Bosse"), this.mocker.getComponentUnderTest()
+            .resolve("bossesSpace.Bosse"));
+        assertEquals(new DocumentReference("bossesWiki", "XWiki", "Bosse"), this.mocker.getComponentUnderTest()
+            .resolve("Bosse", new WikiReference("bossesWiki")));
+        assertEquals(new DocumentReference("bossesWiki", "bossesSpace", "Bosse"), this.mocker.getComponentUnderTest()
+            .resolve("bossesSpace.Bosse", new WikiReference("bossesWiki")));
+        assertEquals(new DocumentReference("bossesWiki", "bossesSpace", "Bosse"), this.mocker.getComponentUnderTest()
+            .resolve("bossesWiki:bossesSpace.Bosse"));
+
+        // If null is passed we expect no reference (i.e. the guest user).
+        assertNull(this.mocker.getComponentUnderTest().resolve(null));
+    }
+}
+
+=====================================================================
+Found a 13 line (123 tokens) duplication in the following files: 
+Starting at line 443 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 720 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 822 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void update() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a terminal document to another terminal document.
+        DocumentReference oldLinkTarget = new DocumentReference("wiki", "A", "B");
+        DocumentReference newLinkTarget = new DocumentReference("wiki", "X", "Y");
+
+=====================================================================
+Found a 9 line (123 tokens) duplication in the following files: 
+Starting at line 486 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-upgrade/src/main/java/org/xwiki/test/ui/UpgradeTest.java
+Starting at line 515 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-upgrade/src/main/java/org/xwiki/test/ui/UpgradeTest.java
+
+        assertTrue(icons.get(STEP_ADMIN_ID).isDone());
+        assertFalse(icons.get(STEP_ADMIN_ID).isActive());
+        assertEquals(STEP_ADMIN_NAME, icons.get(STEP_ADMIN_ID).getName());
+        assertTrue(icons.get(STEP_FLAVOR_ID).isDone());
+        assertFalse(icons.get(STEP_FLAVOR_ID).isActive());
+        assertEquals(STEP_FLAVOR_NAME, icons.get(STEP_FLAVOR_ID).getName());
+        assertTrue(icons.get(STEP_ORPHANED_ID).isDone());
+        assertFalse(icons.get(STEP_ORPHANED_ID).isActive());
+        assertEquals(STEP_ORPHANED_NAME, icons.get(STEP_ORPHANED_ID).getName());
+
+=====================================================================
+Found a 13 line (123 tokens) duplication in the following files: 
+Starting at line 134 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+Starting at line 175 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+
+            warningMessage.selectFirst("a").attr("href"));
+        Element classSheetForm = forms.get(0);
+        assertEquals("Space./}}{{/html}}{{noscript/}}", classSheetForm.selectFirst("[name='parent']").val());
+        assertEquals("/xwiki/bin/view/Space/%2F%7D%7D%7B%7B%2Fhtml%7D%7D%7B%7Bnoscript%2F%7D%7D",
+            classSheetForm.selectFirst("[name='xredirect']").val());
+        assertEquals("#if($doc.documentReference.name == '/}}{{/html}}{{noscript/}}Sheet')/}}{{/html}}"
+            + "{{noscript/}} Sheet#{else}$services.display.title($doc, {'displayerHint': 'default', "
+            + "'outputSyntaxId': 'plain/1.0'})#end", classSheetForm.selectFirst("[name='title']").val());
+        Element classTemplateForm = forms.get(1);
+        assertEquals("Space./}}{{/html}}{{noscript/}}", classTemplateForm.selectFirst("[name='parent']").val());
+        assertEquals("/xwiki/bin/view/Space/%2F%7D%7D%7B%7B%2Fhtml%7D%7D%7B%7Bnoscript%2F%7D%7D",
+            classTemplateForm.selectFirst("[name='xredirect']").val());
+        assertEquals("/}}{{/html}}{{noscript/}} Template", classTemplateForm.selectFirst("[name='title']").val());
+
+=====================================================================
+Found a 16 line (123 tokens) duplication in the following files: 
+Starting at line 362 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+Starting at line 398 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+
+        DocumentReference mainPageReference = new DocumentReference("xwiki", "Space", pageName);
+        XWikiDocument xwikiDocument = this.xwiki.getDocument(mainPageReference, this.context);
+        xwikiDocument.getXClass().addTextField("testField", "Test Field", 10);
+        this.xwiki.saveDocument(xwikiDocument, this.context);
+
+        // Create defaultClassSheetReference
+        XWikiDocument defaultClassSheet =
+            this.xwiki.getDocument(new DocumentReference("xwiki", "Space", "PageSheet"), this.context);
+        this.xwiki.saveDocument(defaultClassSheet, this.context);
+
+        XWikiDocument pageTemplate =
+            this.xwiki.getDocument(new DocumentReference("xwiki", "Space", "PageTemplate"), this.context);
+        pageTemplate.newXObject(mainPageReference, this.context);
+        this.xwiki.saveDocument(pageTemplate, this.context);
+
+        XWikiDocument doc = loadPage(XWIKI_CLASS_SHEET);
+
+=====================================================================
+Found a 12 line (122 tokens) duplication in the following files: 
+Starting at line 70 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-default/src/test/java/org/xwiki/attachment/validation/internal/step/MimetypeAttachmentValidationStepTest.java
+Starting at line 92 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-default/src/test/java/org/xwiki/attachment/validation/internal/step/MimetypeAttachmentValidationStepTest.java
+
+        when(this.attachmentValidationConfiguration.getBlockerMimetypes()).thenReturn(List.of(blockerMimetype));
+
+        AttachmentAccessWrapper wrapper = mock(AttachmentAccessWrapper.class);
+        when(wrapper.getInputStream()).thenReturn(mock(InputStream.class));
+        when(wrapper.getFileName()).thenReturn("test.txt");
+        AttachmentValidationException exception = assertThrows(AttachmentValidationException.class,
+            () -> this.validationStep.validate(wrapper));
+
+        assertEquals("Invalid mimetype [text/plain]", exception.getMessage());
+        assertEquals(Response.Status.UNSUPPORTED_MEDIA_TYPE.getStatusCode(), exception.getHttpStatus());
+        assertEquals("attachment.validation.mimetype.rejected", exception.getTranslationKey());
+        assertEquals(List.of(List.of(), List.of(blockerMimetype)), exception.getTranslationParameters());
+
+=====================================================================
+Found a 25 line (122 tokens) duplication in the following files: 
+Starting at line 245 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterTest.java
+Starting at line 384 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterTest.java
+
+    {
+        // Preferences:
+        //
+        // α: "update" event type enabled for format ALERT
+        //
+        // γ: Inclusive filter on "wikiA:SpaceB"
+        // ζ: Inclusive filter on "wikiA:SpaceM.DocumentN"
+
+        // Mock α
+        NotificationPreference preference = mock(NotificationPreference.class);
+        when(preference.getFormat()).thenReturn(NotificationFormat.ALERT);
+        Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
+        properties.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
+        when(preference.getProperties()).thenReturn(properties);
+
+        // Mock γ
+        WikiReference wikiReference = new WikiReference("wikiA");
+        SpaceReference spaceReferenceB = new SpaceReference("SpaceB", new WikiReference(wikiReference));
+        NotificationFilterPreference prefγ = mockNotificationFilterPreference("wikiA:SpaceB",
+                spaceReferenceB, NotificationFilterType.INCLUSIVE, null);
+
+        // Mock ζ
+        DocumentReference documentReference = new DocumentReference("wikiA", "SpaceM", "DocumentN");
+        NotificationFilterPreference prefζ = mockNotificationFilterPreference("wikiA:SpaceM.DocumentN",
+                documentReference, NotificationFilterType.INCLUSIVE, null);
+
+=====================================================================
+Found a 30 line (122 tokens) duplication in the following files: 
+Starting at line 282 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
+Starting at line 461 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBTreeListClass.java
+
+                List<String> whereStatements = new ArrayList<>();
+
+                // Add the document to the query only if it is needed.
+                if (usesDoc) {
+                    fromStatements.add("XWikiDocument as doc");
+                    if (usesObj) {
+                        whereStatements.add("doc.fullName=obj.name");
+                    }
+                }
+                // Add the object to the query only if it is needed.
+                if (usesObj) {
+                    fromStatements.add("BaseObject as obj");
+                    if (hasClassname) {
+                        whereStatements.add("obj.className='" + classname + "'");
+                    }
+                }
+
+                // Add the first column to the query.
+                if (idField.startsWith("doc.") || idField.startsWith("obj.")) {
+                    select.append(idField);
+                } else if (!hasClassname) {
+                    select.append("doc." + idField);
+                } else {
+                    select.append("idprop.value");
+                    fromStatements.add("StringProperty as idprop");
+                    whereStatements.add("obj.id=idprop.id.id and idprop.id.name='" + idField + "'");
+                }
+
+                // If specified, add the second column to the query.
+                if (hasValueField) {
+
+=====================================================================
+Found a 15 line (122 tokens) duplication in the following files: 
+Starting at line 922 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1591 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void existingDocumentFromUITemplateProviderSpecified() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
+        String templateProviderFullName = "XWiki.MyTemplateProvider";
+        when(mockRequest.getParameter("spaceReference")).thenReturn("X");
+        when(mockRequest.getParameter("name")).thenReturn("Y");
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+
+=====================================================================
+Found a 15 line (122 tokens) duplication in the following files: 
+Starting at line 215 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+Starting at line 277 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+
+        when(this.authorization.hasAccess(Right.VIEW, userReference, oldReference)).thenReturn(true);
+
+        DocumentReference authorReference = new DocumentReference("wiki", "Users", "Bob");
+        when(this.authorization.hasAccess(Right.DELETE, authorReference, oldReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, newReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, oldReference)).thenReturn(true);
+
+        MoveRequest request = createRequest(oldReference, newReference.getParent());
+        request.setCheckRights(true);
+        request.setCheckAuthorRights(true);
+        request.setUserReference(userReference);
+        request.setAuthorReference(authorReference);
+        run(request);
+
+        assertEquals("You don't have sufficient permissions over the destination document [wiki:Two.Page].",
+
+=====================================================================
+Found a 12 line (121 tokens) duplication in the following files: 
+Starting at line 280 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 307 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        assertEquals("Page only", preferences.get(0).getScope());
+        assertEquals(pageName, preferences.get(0).getLocation());
+        assertEquals(CustomNotificationFilterPreference.FilterAction.NOTIFY_EVENT,
+            preferences.get(0).getFilterAction());
+        assertTrue(preferences.get(0).getEventTypes().isEmpty());
+        assertTrue(preferences.get(0).getFormats().containsAll(List.of("Email", "Alert")));
+        assertTrue(preferences.get(0).isEnabled());
+
+        // back to the page
+        testUtils.gotoPage(testReference);
+        watchButtonElement = new NotificationWatchButtonElement();
+        assertTrue(watchButtonElement.isWatched());
+
+=====================================================================
+Found a 25 line (121 tokens) duplication in the following files: 
+Starting at line 138 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+Starting at line 105 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+Starting at line 153 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+
+        BaseProperty property = new LargeStringProperty();
+        property.setName(getName());
+        return property;
+    }
+
+    @Override
+    public BaseProperty fromString(String value) throws XWikiException
+    {
+        BaseProperty prop = newProperty();
+        prop.setValue(value);
+        return prop;
+    }
+
+    @Override
+    public BaseProperty fromStringArray(String[] strings)
+    {
+        List<String> list;
+        if ((strings.length == 1) && (getDisplayType().equals(DISPLAYTYPE_INPUT) || isMultiSelect())) {
+            list = getListFromString(strings[0], getSeparators(), false);
+        } else {
+            list = Arrays.asList(strings);
+        }
+
+        BaseProperty prop = newProperty();
+        fromList(prop, list);
+
+=====================================================================
+Found a 14 line (121 tokens) duplication in the following files: 
+Starting at line 86 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+Starting at line 230 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+
+        assertEquals("1.42", document.getVersion());
+
+        // Attachment
+
+        assertEquals(1, document.getAttachmentList().size());
+        XWikiAttachment attachment = document.getAttachment("attachment.txt");
+        assertEquals("attachment.txt", attachment.getFilename());
+        assertEquals(10, attachment.getLongSize());
+        assertTrue(Arrays.equals(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+            attachment.getContent(this.oldcore.getXWikiContext())));
+
+        assertEquals("XWiki.attachmentAuthor", attachment.getAuthor());
+        assertEquals(toDate("2000-01-05 00:00:00.0 UTC"), attachment.getDate());
+        assertEquals("15.1", attachment.getVersion());
+
+=====================================================================
+Found a 10 line (121 tokens) duplication in the following files: 
+Starting at line 237 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+Starting at line 268 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+Starting at line 298 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+
+    void moveDocumentToRestrictedDestinationAuthor() throws Throwable
+    {
+        DocumentReference oldReference = new DocumentReference("wiki", "One", "Page");
+        DocumentReference newReference = new DocumentReference("wiki", "Two", "Page");
+        when(this.modelBridge.exists(oldReference)).thenReturn(true);
+
+        DocumentReference userReference = new DocumentReference("wiki", "Users", "Alice");
+        when(this.authorization.hasAccess(Right.DELETE, userReference, oldReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, userReference, newReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, userReference, oldReference)).thenReturn(true);
+
+=====================================================================
+Found a 12 line (121 tokens) duplication in the following files: 
+Starting at line 148 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/framework/AbstractHttpIT.java
+Starting at line 94 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/AbstractTest.java
+
+        ComponentManager componentManager = new EmbeddableComponentManager();
+
+        // Only load the minimal number of components required for the test framework, for both performance reasons
+        // and for avoiding having to declare dependencies such as HttpServletRequest.
+        ComponentAnnotationLoader loader = new ComponentAnnotationLoader();
+        List<ComponentDeclaration> componentDeclarations = new ArrayList<>();
+        componentDeclarations.add(new ComponentDeclaration(DefaultStringEntityReferenceResolver.class.getName()));
+        componentDeclarations.add(new ComponentDeclaration(DefaultStringEntityReferenceSerializer.class.getName()));
+        componentDeclarations.add(new ComponentDeclaration(RelativeStringEntityReferenceResolver.class.getName()));
+        componentDeclarations.add(new ComponentDeclaration(DefaultEntityReferenceProvider.class.getName()));
+        componentDeclarations.add(new ComponentDeclaration(DefaultModelConfiguration.class.getName()));
+        componentDeclarations.add(new ComponentDeclaration(DefaultSymbolScheme.class.getName()));
+
+=====================================================================
+Found a 22 line (121 tokens) duplication in the following files: 
+Starting at line 129 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/internal/AuthorizationManagerTest.java
+Starting at line 158 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/internal/AuthorizationManagerTest.java
+
+        EntityReference document = null;
+
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.LOGIN, user,
+            document, ctx);
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.VIEW, user,
+            document, ctx);
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.EDIT, user,
+            document, ctx);
+        assertAccessFalse("User from global wiki should have the same rights on empty subwiki", Right.DELETE, user,
+            document, ctx);
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.REGISTER, user,
+            document, ctx);
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.COMMENT, user,
+            document, ctx);
+        assertAccessFalse("User from global wiki should have the same rights on empty subwiki", Right.PROGRAM, user,
+            document, ctx);
+        assertAccessFalse("User from global wiki should have the same rights on empty subwiki", Right.ADMIN, user,
+            document, ctx);
+    }
+
+    @Test
+    public void testRightOnTopLevel() throws Exception
+
+=====================================================================
+Found a 17 line (120 tokens) duplication in the following files: 
+Starting at line 134 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/test/java/org/xwiki/invitation/InvitationCommonPageTest.java
+Starting at line 171 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/test/java/org/xwiki/invitation/InvitationCommonPageTest.java
+
+        XWikiDocument doc = this.xwiki.getDocument(documentReference, this.context);
+        this.xwiki.saveDocument(doc, this.context);
+        this.context.setDoc(doc);
+
+        // Create a WebHome file in the same space as InvitationCommon, with an XClass containing the expected fields.
+        DocumentReference configDocumentReference =
+            new DocumentReference("xwiki", "<script>console.log</script>", "WebHome");
+        XWikiDocument configDoc = this.xwiki.getDocument(configDocumentReference, this.context);
+        configDoc.getXClass().addTextField("from_address", "From Address", 30);
+        this.xwiki.saveDocument(configDoc, this.context);
+
+        // Initialize the document in the same space as InvitationCommon, containing an XObject with a WebHome XObject.
+        XWikiDocument hopefullyNonExistantSpaceDoc = this.xwiki.getDocument(
+            new DocumentReference("xwiki", "<script>console.log</script>", "HopefullyNonexistantSpace"), this.context);
+        BaseObject invitationConfigXObject =
+            hopefullyNonExistantSpaceDoc.newXObject(configDocumentReference, this.context);
+        invitationConfigXObject.set("from_address", "<script>console.log('from_address')</script>", this.context);
+
+=====================================================================
+Found a 29 line (120 tokens) duplication in the following files: 
+Starting at line 56 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/configuration/GeneralMailConfigClassDocumentConfigurationSourceTest.java
+Starting at line 56 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/configuration/SendMailConfigClassDocumentConfigurationSourceTest.java
+
+    private GeneralMailConfigClassDocumentConfigurationSource source;
+
+    @MockComponent
+    private ConverterManager converterManager;
+
+    @MockComponent
+    private CacheManager cacheManager;
+
+    @MockComponent
+    private WikiDescriptorManager wikiDescriptorManager;
+
+    @MockComponent
+    private Provider<XWikiContext> xcontextProvider;
+
+    @BeforeComponent
+    public void before() throws Exception
+    {
+        Cache<Object> cache = mock(Cache.class);
+        when(this.cacheManager.createNewCache(any(CacheConfiguration.class))).thenReturn(cache);
+    }
+
+    @Test
+    void getPropertyWhenSendMailConfigClassXObjectExists() throws Exception
+    {
+        when(this.converterManager.convert(String.class, "value")).thenReturn("value");
+
+        when(this.wikiDescriptorManager.getCurrentWikiId()).thenReturn("wiki");
+
+        LocalDocumentReference classReference = new LocalDocumentReference("Mail", "GeneralMailConfigClass");
+
+=====================================================================
+Found a 13 line (120 tokens) duplication in the following files: 
+Starting at line 96 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitReferenceEntityReferenceResolverTest.java
+Starting at line 92 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringEntityReferenceResolverTest.java
+
+            new EntityReference("space", EntityType.SPACE)), EntityType.DOCUMENT,
+            new EntityReference("page", EntityType.DOCUMENT, new EntityReference("wiki", EntityType.WIKI)));
+
+        assertEquals("page", reference.getName());
+        assertEquals(EntityType.DOCUMENT, reference.getType());
+        assertEquals("space", reference.getParent().getName());
+        assertEquals(EntityType.SPACE, reference.getParent().getType());
+        assertEquals("wiki", reference.getParent().getParent().getName());
+        assertEquals(EntityType.WIKI, reference.getParent().getParent().getType());
+    }
+
+    @Test
+    public void resolveWithExplicitReferenceWithHolesAndIncompatibleParameter()
+
+=====================================================================
+Found a 11 line (120 tokens) duplication in the following files: 
+Starting at line 126 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+Starting at line 167 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+Starting at line 211 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+
+    void onEventWhenNonTerminalDocumentOnMainWiki() throws Exception
+    {
+        DocumentReference source = new DocumentReference("xwiki", "PageA", "WebHome");
+        DocumentReference target = new DocumentReference("xwiki", "PageB", "WebHome");
+        when(serializer.serialize(new SpaceReference("PageA", new WikiReference("xwiki")))).thenReturn("xwiki:PageA");
+        when(serializer.serialize(new SpaceReference("PageB", new WikiReference("xwiki")))).thenReturn("xwiki:PageB");
+        when(serializer.serialize(source)).thenReturn("xwiki:PageA.WebHome");
+        when(serializer.serialize(target)).thenReturn("xwiki:PageB.WebHome");
+
+        // Mock
+        when(wikiDescriptorManager.getAllIds()).thenReturn(List.of("mainWiki"));
+
+=====================================================================
+Found a 18 line (120 tokens) duplication in the following files: 
+Starting at line 345 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 379 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 419 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        when(this.recordableEventDescriptorHelper.hasDescriptor("create", USER_REFERENCE)).thenReturn(false);
+
+        // Test
+        NotificationParameters parameters = new NotificationParameters();
+        parameters.user = USER_REFERENCE;
+        parameters.format = NotificationFormat.ALERT;
+        parameters.fromDate = this.startDate;
+        parameters.filters = Arrays.asList(notificationFilter1);
+        parameters.preferences = Arrays.asList(this.pref1);
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_HIDDEN, true, CompareType.EQUALS, true), conditions.next());
+
+=====================================================================
+Found a 18 line (120 tokens) duplication in the following files: 
+Starting at line 802 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+Starting at line 94 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StaticListClass.java
+
+    }
+
+    @Override
+    public void displayEdit(StringBuffer buffer, String name, String prefix, BaseCollection object,
+        XWikiContext context)
+    {
+        if (getDisplayType().equals(DISPLAYTYPE_INPUT)) {
+            input input = new input();
+            input.setAttributeFilter(new XMLAttributeValueFilter());
+            BaseProperty prop = (BaseProperty) object.safeget(name);
+            if (prop != null) {
+                input.setValue(this.toFormString(prop));
+            }
+            input.setType("text");
+            input.setSize(getSize());
+            input.setName(prefix + name);
+            input.setID(prefix + name);
+            input.setDisabled(isDisabled());
+
+=====================================================================
+Found a 12 line (120 tokens) duplication in the following files: 
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentRenderingTest.java
+Starting at line 205 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+
+        this.oldcore.getXWikiContext().setDoc(this.document);
+
+        this.baseClass = this.document.getXClass();
+        this.baseClass.addTextField("string", "String", 30);
+        this.baseClass.addTextAreaField("area", "Area", 10, 10);
+        this.baseClass.addTextAreaField("puretextarea", "Pure text area", 10, 10);
+        // set the text areas an non interpreted content
+        ((TextAreaClass) this.baseClass.getField("puretextarea")).setContentType("puretext");
+        this.baseClass.addPasswordField("passwd", "Password", 30);
+        this.baseClass.addBooleanField("boolean", "Boolean", "yesno");
+        this.baseClass.addNumberField("int", "Int", 10, "integer");
+        this.baseClass.addStaticListField("stringlist", "StringList", "value1, value2");
+
+=====================================================================
+Found a 15 line (120 tokens) duplication in the following files: 
+Starting at line 607 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+Starting at line 628 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+
+    void restoreDeletedDocument() throws Exception
+    {
+        long deletedDocumentId = 42;
+        DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
+
+        XWikiDeletedDocument deletedDocument = mock(XWikiDeletedDocument.class);
+        when(deletedDocument.getDocumentReference()).thenReturn(documentReference);
+        when(deletedDocument.getId()).thenReturn(deletedDocumentId);
+        when(xwiki.getDeletedDocument(deletedDocumentId, xcontext)).thenReturn(deletedDocument);
+
+        when(xwiki.exists(documentReference, xcontext)).thenReturn(false);
+        when(request.isCheckAuthorRights()).thenReturn(false);
+        when(request.isCheckRights()).thenReturn(false);
+
+        assertTrue(this.modelBridge.restoreDeletedDocument(deletedDocumentId, request));
+
+=====================================================================
+Found a 12 line (120 tokens) duplication in the following files: 
+Starting at line 154 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/AuthenticationMailSenderTest.java
+Starting at line 193 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/AuthenticationMailSenderTest.java
+Starting at line 226 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/AuthenticationMailSenderTest.java
+
+        when(this.mailSenderConfiguration.getFromAddress()).thenReturn(fromAdress);
+        when(xWikiContext.getLocale()).thenReturn(Locale.CANADA);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("from", fromAdress);
+        parameters.put("to", email);
+        parameters.put("language", Locale.CANADA);
+        parameters.put("type", "Reset Password");
+        Map<String, String> velocityVariables = new HashMap<>();
+        velocityVariables.put("userName", username);
+        velocityVariables.put("passwordResetURL", resetPasswordUrl.toExternalForm());
+        parameters.put("velocityVariables", velocityVariables);
+
+=====================================================================
+Found a 11 line (120 tokens) duplication in the following files: 
+Starting at line 244 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManagerTest.java
+Starting at line 267 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManagerTest.java
+Starting at line 290 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManagerTest.java
+Starting at line 313 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManagerTest.java
+
+        Thread.sleep(1500);
+        assertFalse(this.defaultAuthenticationFailureManager.recordAuthenticationFailure(this.failingLogin, request));
+        assertFalse(this.defaultAuthenticationFailureManager.recordAuthenticationFailure(this.failingLogin, request));
+        assertTrue(this.defaultAuthenticationFailureManager.recordAuthenticationFailure(this.failingLogin, request));
+
+        verify(this.observationManager, times(5)).notify(new AuthenticationFailureEvent(), this.failingLogin);
+        verify(this.observationManager).notify(new AuthenticationFailureLimitReachedEvent(),
+            this.failingLogin);
+        verify(this.strategy1).notify(failingLogin);
+        verify(this.strategy2).notify(failingLogin);
+        verify(this.sessionFailing).set(eq("anotherId"), any(Instant.class));
+
+=====================================================================
+Found a 9 line (119 tokens) duplication in the following files: 
+Starting at line 63 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultReferenceEntityReferenceResolverTest.java
+Starting at line 66 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultStringEntityReferenceResolverTest.java
+
+    {
+        when(this.referenceProvider.getDefaultReference(EntityType.WIKI)).thenReturn(DEFAULT_WIKI_REFERENCE);
+        when(this.referenceProvider.getDefaultReference(EntityType.SPACE)).thenReturn(DEFAULT_SPACE_REFERENCE);
+        when(this.referenceProvider.getDefaultReference(EntityType.DOCUMENT)).thenReturn(DEFAULT_DOCUMENT_REFERENCE);
+        when(this.referenceProvider.getDefaultReference(EntityType.ATTACHMENT)).thenReturn(DEFAULT_ATTACHMENT_REFERENCE);
+        when(this.referenceProvider.getDefaultReference(EntityType.OBJECT)).thenReturn(DEFAULT_OBJECT_REFERENCE);
+        when(this.referenceProvider.getDefaultReference(EntityType.OBJECT_PROPERTY))
+            .thenReturn(DEFAULT_OBJECT_PROPERTY_REFERENCE);
+        when(this.referenceProvider.getDefaultReference(EntityType.PAGE)).thenReturn(DEFAULT_PAGE_REFERENCE);
+
+=====================================================================
+Found a 15 line (119 tokens) duplication in the following files: 
+Starting at line 256 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+Starting at line 307 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+
+        obj.setLargeStringValue("template.vm", "parsing a field");
+        this.xwiki.saveDocument(skinDocument, this.oldcore.getXWikiContext());
+
+        this.oldcore.getXWikiContext().put("skin", "XWiki.Skin");
+        assertEquals("XWiki.Skin", this.xwiki.getSkin(this.oldcore.getXWikiContext()));
+        assertFalse(this.xwiki.getDocument(mySkinReference, this.oldcore.getXWikiContext()).isNew());
+        assertEquals(skinDocument, this.xwiki.getDocument(mySkinReference, this.oldcore.getXWikiContext()));
+        assertEquals("parsing a field", this.xwiki.parseTemplate("template.vm", this.oldcore.getXWikiContext()));
+    }
+
+    /**
+     * See XWIKI-2096
+     */
+    @Test
+    void parseTemplateConsidersAttachment() throws XWikiException
+
+=====================================================================
+Found a 17 line (119 tokens) duplication in the following files: 
+Starting at line 481 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+Starting at line 536 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+
+        importFromXML("documentwithobjectwithoutnumberandclass", outputProperties);
+
+        XWikiDocument document = this.oldcore.getSpyXWiki().getDocument(new DocumentReference("wiki", "space", "page"),
+            this.oldcore.getXWikiContext());
+
+        assertFalse(document.isNew());
+
+        // Objects
+
+        Map<DocumentReference, List<BaseObject>> objects = document.getXObjects();
+        assertEquals(1, objects.size());
+
+        List<BaseObject> documentObjects = objects.get(new DocumentReference("wiki", "otherspace", "otherclass"));
+        assertEquals(1, documentObjects.size());
+        BaseObject documentObject = documentObjects.get(0);
+        assertEquals(0, documentObject.getNumber());
+        assertEquals(1, documentObject.getFieldList().size());
+
+=====================================================================
+Found a 17 line (119 tokens) duplication in the following files: 
+Starting at line 47 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectAtPageVersionResourceImpl.java
+Starting at line 52 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertiesAtPageVersionResourceImpl.java
+Starting at line 52 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertyAtPageVersionResourceImpl.java
+
+            Integer objectNumber, Boolean withPrettyName) throws XWikiRestException
+    {
+        try {
+            DocumentInfo documentInfo = getDocumentInfo(wikiName, spaceName, pageName, null, version, true, false);
+
+            Document doc = documentInfo.getDocument();
+
+            XWikiDocument xwikiDocument = Utils.getXWiki(componentManager)
+                    .getDocument(doc.getDocumentReference(), Utils.getXWikiContext(componentManager));
+
+            xwikiDocument = Utils.getXWiki(componentManager)
+                    .getDocument(xwikiDocument, doc.getVersion(), Utils.getXWikiContext(componentManager));
+
+            com.xpn.xwiki.objects.BaseObject baseObject = xwikiDocument.getObject(className, objectNumber);
+            if (baseObject == null) {
+                throw new WebApplicationException(Status.NOT_FOUND);
+            }
+
+=====================================================================
+Found a 10 line (119 tokens) duplication in the following files: 
+Starting at line 158 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/converter/DefaultRequestParameterConverterTest.java
+Starting at line 173 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/converter/DefaultRequestParameterConverterTest.java
+
+        when(converter1.convert(any(ServletRequest.class))).then(invocationOnMock -> {
+            ServletRequest request = invocationOnMock.getArgument(0);
+            assertEquals("converted content", request.getParameter("test"));
+            assertEquals("Other content", request.getParameter("testHtml"));
+            assertEquals(2, request.getParameterMap().size());
+
+            JakartaRequestParameterConversionResult result = mock(JakartaRequestParameterConversionResult.class);
+            when(result.getRequest()).thenReturn((MutableJakartaServletRequest) request);
+            when(result.getErrors()).thenReturn(Map.of());
+            when(result.getOutput()).thenReturn(Map.of(
+
+=====================================================================
+Found a 12 line (118 tokens) duplication in the following files: 
+Starting at line 330 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509KeyWikiStoreTest.java
+Starting at line 350 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509KeyWikiStoreTest.java
+
+    public void retrievePrivateKeyFromDocument() throws Exception
+    {
+        XWikiDocument storeDoc = mock(XWikiDocument.class);
+        when(xwiki.getDocument(new DocumentReference(WIKI, SPACE, DOCUMENT), xcontext)).thenReturn(storeDoc);
+
+        BaseObject certObj = mock(BaseObject.class);
+        when(storeDoc.getXObject(X509CertificateWikiStore.CERTIFICATECLASS)).thenReturn(certObj);
+        when(certObj.getLargeStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_CERTIFICATE)).thenReturn(ENCODED_CERTIFICATE);
+
+        BaseObject pkObj = mock(BaseObject.class);
+        when(storeDoc.getXObject(X509KeyWikiStore.PRIVATEKEYCLASS)).thenReturn(pkObj);
+        when(pkObj.getLargeStringValue(X509KeyWikiStore.PRIVATEKEYCLASS_PROP_KEY)).thenReturn(ENCODED_PRIVATEKEY);
+
+=====================================================================
+Found a 14 line (118 tokens) duplication in the following files: 
+Starting at line 144 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/test/java/org/xwiki/rendering/internal/macro/dashboard/GadgetObjectRequiredRightAnalyzerTest.java
+Starting at line 165 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/test/java/org/xwiki/rendering/internal/macro/dashboard/GadgetObjectRequiredRightAnalyzerTest.java
+
+        when(this.contentParser.parse(content, Syntax.XWIKI_2_1, this.documentReference)).thenReturn(xdom);
+
+        RequiredRightAnalysisResult wikiResult = mock();
+        when(this.xdomRequiredRightAnalyzer.analyze(xdom)).thenReturn(List.of(wikiResult));
+
+        List<RequiredRightAnalysisResult> analysisResults = this.analyzer.analyze(this.object);
+
+        verify(this.xdomRequiredRightAnalyzer).analyze(xdom);
+        assertEquals(this.object.getReference(),
+            xdom.getMetaData().getMetaData().get(XDOMRequiredRightAnalyzer.ENTITY_REFERENCE_METADATA));
+
+        assertEquals(1, analysisResults.size());
+        assertEquals(wikiResult, analysisResults.get(0));
+    }
+
+=====================================================================
+Found a 19 line (118 tokens) duplication in the following files: 
+Starting at line 70 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/template/AbstractTemplateMimeMessageFactory.java
+Starting at line 69 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/text/TextMimeMessageFactory.java
+
+        ExtendedMimeMessage message = new ExtendedMimeMessage();
+
+        // Handle optional "from" address.
+        Address from = this.converterManager.convert(Address.class, parameters.get("from"));
+        if (from != null) {
+            message.setFrom(from);
+        }
+
+        // Handle optional "to", "cc" and "bcc" addresses.
+        setRecipient(message, Message.RecipientType.TO, parameters.get("to"));
+        setRecipient(message, Message.RecipientType.CC, parameters.get("cc"));
+        setRecipient(message, Message.RecipientType.BCC, parameters.get("bcc"));
+
+        // Handle optional "type" parameter to set the mail type
+        // Set the Message type if passed in parameters
+        String type = (String) parameters.get("type");
+        if (type != null) {
+            message.setType(type);
+        }
+
+=====================================================================
+Found a 13 line (118 tokens) duplication in the following files: 
+Starting at line 111 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/template/DefaultMailTemplateManagerTest.java
+Starting at line 249 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/template/DefaultMailTemplateManagerTest.java
+
+    public void evaluate() throws Exception
+    {
+        DocumentAccessBridge documentBridge = this.componentManager.getInstance(DocumentAccessBridge.class);
+        DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
+
+        when(documentBridge.getProperty(same(documentReference), any(), anyInt(), eq("html")))
+            .thenReturn("Hello <b>${name}</b> <br />${email}");
+
+        VelocityEngine velocityEngine = mock(VelocityEngine.class);
+        VelocityManager velocityManager = this.componentManager.getInstance(VelocityManager.class);
+        when(velocityManager.getVelocityEngine()).thenReturn(velocityEngine);
+        when(this.velocityEvaluator.evaluateVelocity(eq("Hello <b>${name}</b> <br />${email}"), any(),
+            any())).thenReturn("Hello <b>John Doe</b> <br />john@doe.com");
+
+=====================================================================
+Found a 13 line (118 tokens) duplication in the following files: 
+Starting at line 98 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/UserMentionsFormatterTest.java
+Starting at line 116 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/UserMentionsFormatterTest.java
+Starting at line 134 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/UserMentionsFormatterTest.java
+
+    void formatMentionNoLastName()
+    {
+        UserReference userReference = mock(UserReference.class);
+        UserProperties userProperties = mock(UserProperties.class);
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "User");
+
+        when(this.userReferenceResolver.resolve("xwiki:XWiki.User")).thenReturn(userReference);
+        when(this.userPropertiesResolver.resolve(userReference)).thenReturn(userProperties);
+        when(this.documentReferenceResolver.resolve("xwiki:XWiki.User")).thenReturn(documentReference);
+        when(userProperties.getFirstName()).thenReturn("First Name");
+        when(userProperties.getLastName()).thenReturn(null);
+
+        String actual = this.formatter.formatMention("xwiki:XWiki.User", FULL_NAME);
+
+=====================================================================
+Found a 31 line (118 tokens) duplication in the following files: 
+Starting at line 72 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/AttachmentEventGeneratorListener.java
+Starting at line 68 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListener.java
+Starting at line 68 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XObjectEventGeneratorListener.java
+
+    }
+
+    @Override
+    public List<Event> getEvents()
+    {
+        return EVENTS;
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        XWikiDocument doc = (XWikiDocument) source;
+        XWikiDocument originalDoc = doc.getOriginalDocument();
+        XWikiContext context = (XWikiContext) data;
+
+        if (event instanceof DocumentUpdatedEvent) {
+            onDocumentUpdatedEvent(originalDoc, doc, context);
+        } else if (event instanceof DocumentDeletedEvent) {
+            onDocumentDeletedEvent(originalDoc, doc, context);
+        } else if (event instanceof DocumentCreatedEvent) {
+            onDocumentCreatedEvent(originalDoc, doc, context);
+        }
+    }
+
+    /**
+     * @param originalDoc the previous version of the document
+     * @param doc the new version of the document
+     * @param context the XWiki context
+     */
+    private void onDocumentCreatedEvent(XWikiDocument originalDoc, XWikiDocument doc, XWikiContext context)
+    {
+
+=====================================================================
+Found a 17 line (118 tokens) duplication in the following files: 
+Starting at line 378 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+Starting at line 415 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+
+            invocation.<XWikiDocument>getArgument(1).setContent("modified content");
+            return null;
+        }).when(mockListener).onEvent(any(), any(), any());
+
+        doAnswer(invocation -> {
+            XWikiDocument document = invocation.getArgument(0);
+            assertFalse(document.isMetaDataDirty());
+            assertFalse(document.isContentDirty());
+
+            return null;
+        }).when(this.oldcore.getMockStore()).saveXWikiDoc(any(), any());
+
+        ObservationManager om = this.oldcore.getMocker().getInstance(ObservationManager.class);
+        om.addListener(mockListener);
+
+        XWikiDocument document = new XWikiDocument(ref);
+        document.setContent("the content");
+
+=====================================================================
+Found a 8 line (118 tokens) duplication in the following files: 
+Starting at line 358 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+Starting at line 416 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+
+        this.document.readObjectsFromFormUpdateOrCreate(eform, context);
+
+        assertEquals(43, this.document.getXObjectSize(baseClass.getDocumentReference()));
+        assertEquals("bloublou",
+            this.document.getXObject(baseClass.getDocumentReference(), 0).getStringValue("string"));
+        assertEquals(42, this.document.getXObject(baseClass.getDocumentReference(), 0).getIntValue("int"));
+        assertEquals("string2", this.document.getXObject(baseClass.getDocumentReference(), 1).getStringValue("string"));
+        assertEquals(7, this.document.getXObject(baseClass.getDocumentReference(), 1).getIntValue("int"));
+
+=====================================================================
+Found a 13 line (118 tokens) duplication in the following files: 
+Starting at line 87 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetgroupsPageTest.java
+Starting at line 112 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetgroupsPageTest.java
+
+        this.request.put("limit", "10");
+        this.request.put("offset", "1");
+
+        DocumentReference group1DocumentReference = new DocumentReference("xwiki", "XWiki", "G1");
+        DocumentReference group2DocumentReference = new DocumentReference("xwiki", "XWiki", "G2");
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, group2DocumentReference)).thenReturn(false);
+        XWikiDocument group1 = this.xwiki.getDocument(group1DocumentReference, this.context);
+        XWikiDocument group2 = this.xwiki.getDocument(group2DocumentReference, this.context);
+
+        
+        doReturn(Arrays.asList(group1, group2))
+            .when(this.groupService)
+            .getAllMatchedGroups(eq(null), eq(true), eq(10), eq(0), any(), eq(this.context));
+
+=====================================================================
+Found a 13 line (118 tokens) duplication in the following files: 
+Starting at line 87 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetusersPageTest.java
+Starting at line 112 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/GetusersPageTest.java
+
+        this.request.put("limit", "10");
+        this.request.put("offset", "1");
+
+        DocumentReference user1DocumentReference = new DocumentReference("xwiki", "XWiki", "U1");
+        DocumentReference user2DocumentReference = new DocumentReference("xwiki", "XWiki", "U2");
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, user2DocumentReference)).thenReturn(false);
+        XWikiDocument user1 = this.xwiki.getDocument(user1DocumentReference, this.context);
+        XWikiDocument user2 = this.xwiki.getDocument(user2DocumentReference, this.context);
+
+        
+        doReturn(Arrays.asList(user1, user2))
+            .when(this.groupService)
+            .getAllMatchedUsers(eq(null), eq(true), eq(10), eq(0), any(), eq(this.context));
+
+=====================================================================
+Found a 18 line (118 tokens) duplication in the following files: 
+Starting at line 173 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/NotificationMailDefaultHtmlTest.java
+Starting at line 395 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/NotificationMailDefaultHtmlTest.java
+
+        when(this.diffDisplayerScriptService.unified(any(String.class), any(String.class), isNull()))
+            .then(invocationOnMock -> {
+            String previous = invocationOnMock.getArgument(0);
+            assertEquals("", previous);
+
+            String next = invocationOnMock.getArgument(1);
+            assertEquals("Content", next);
+            UnifiedDiffBlock<String, Character> result = new UnifiedDiffBlock<>();
+            result.add(0, new UnifiedDiffElement<>(0, UnifiedDiffElement.Type.ADDED, "Content"));
+            return List.of(result);
+        });
+
+        this.scriptContext.setAttribute("event", new CompositeEvent(testEvent), ScriptContext.GLOBAL_SCOPE);
+
+        String result = this.templateManager.render(MAIL_NOTIF_TEMPLATE);
+        String expectedResult = "<table style=\"width: 100%\">\n"
+            + "    <tr>\n"
+            + "                        "
+
+=====================================================================
+Found a 17 line (118 tokens) duplication in the following files: 
+Starting at line 124 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverterTest.java
+Starting at line 161 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverterTest.java
+
+        assertEquals("", this.converter.toHTML(source, syntax.toIdString()));
+
+        // Verify that the macro transformations have been executed.
+        Transformation macroTransformation = this.componentManager.getInstance(Transformation.class, "macro");
+        RenderingContext renderingContext = this.componentManager.getInstance(RenderingContext.class);
+
+        // It's very important to verify that a transformation context id is set as otherwise if the content being
+        // edited has different velocity macros executing, they'll be executed in isolation and thus what's defined in
+        // one won't be visible from the other ones (For example see https://jira.xwiki.org/browse/XWIKI-11695).
+        ArgumentCaptor<TransformationContext> txContextArgument = ArgumentCaptor.forClass(TransformationContext.class);
+        verify((MutableRenderingContext) renderingContext).transformInContext(same(macroTransformation),
+            txContextArgument.capture(), same(xdom));
+        assertEquals("wysiwygtxid", txContextArgument.getValue().getId());
+
+        // Verify the XDOM is rendered to Annotated XHTML.
+        BlockRenderer xhtmlRenderer = this.componentManager.getInstance(BlockRenderer.class, "annotatedhtml/5.0");
+        verify(xhtmlRenderer).render(same(xdom), any(WikiPrinter.class));
+
+=====================================================================
+Found a 15 line (117 tokens) duplication in the following files: 
+Starting at line 501 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+Starting at line 641 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+
+        setup.login(deleteVersionTestUser, deleteVersionTestUser);
+
+        // first check that the right is properly denied in the objects
+        setup.gotoPage(xwikiPreferences, "edit", "editor=object");
+        objectEditPage = new ObjectEditPage();
+        rightObjects = objectEditPage.getObjectsOfClass("XWiki.XWikiGlobalRights", false);
+        rightObject = rightObjects.get(rightObjects.size() - 1);
+        rightObject.displayObject();
+        assertEquals(deleteVersionTestUser, rightObject.getFieldValue(rightObject.byPropertyName("users")));
+        assertEquals("programming", rightObject.getFieldValue(rightObject.byPropertyName("levels")));
+        assertEquals("0", rightObject.getFieldValue(rightObject.byPropertyName("allow")));
+
+        setup.gotoPage(xwikiPreferences, "view", "viewer=history");
+        historyPane = new HistoryPane();
+        historyPane = historyPane.showMinorEdits();
+
+=====================================================================
+Found a 15 line (117 tokens) duplication in the following files: 
+Starting at line 612 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+Starting at line 641 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+
+        setup.login(deleteVersionTestUser, deleteVersionTestUser);
+
+        // first check that the right is properly denied in the objects
+        setup.gotoPage(xwikiPreferences, "edit", "editor=object");
+        objectEditPage = new ObjectEditPage();
+        rightObjects = objectEditPage.getObjectsOfClass("XWiki.XWikiGlobalRights", false);
+        rightObject = rightObjects.get(rightObjects.size() - 1);
+        rightObject.displayObject();
+        assertEquals(deleteVersionTestUser, rightObject.getFieldValue(rightObject.byPropertyName("users")));
+        assertEquals("programming", rightObject.getFieldValue(rightObject.byPropertyName("levels")));
+        assertEquals("0", rightObject.getFieldValue(rightObject.byPropertyName("allow")));
+
+        setup.gotoPage(xwikiPreferences, "view", "viewer=history");
+        historyPane = new HistoryPane();
+        historyPane = historyPane.showMinorEdits();
+
+=====================================================================
+Found a 11 line (117 tokens) duplication in the following files: 
+Starting at line 233 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/ChildDocumentsTreeNodeGroupTest.java
+Starting at line 280 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/ChildDocumentsTreeNodeGroupTest.java
+
+            .thenReturn(new DocumentReference("wiki", "Path", "WebHome"));
+
+        DocumentReference alice = new DocumentReference("Alice", this.documentReference.getLastSpaceReference());
+        when(this.entityTreeNodeIdConverter.convert(EntityReference.class, "document:wiki:Path.To.Page.Alice"))
+            .thenReturn(alice);
+        when(this.localEntityReferenceSerializer.serialize(alice)).thenReturn("Path.To.Page.Alice");
+
+        DocumentReference bob = new DocumentReference("wiki", List.of("Path", "To", "Page", "Bob"), "WebHome");
+        when(this.entityTreeNodeIdConverter.convert(EntityReference.class, "document:wiki:Path.To.Page.Bob.WebHome"))
+            .thenReturn(bob);
+        when(this.localEntityReferenceSerializer.serialize(bob.getParent())).thenReturn("Path.To.Page.Bob");
+
+=====================================================================
+Found a 30 line (117 tokens) duplication in the following files: 
+Starting at line 78 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-default/src/main/java/org/xwiki/mail/script/DeprecatedMailSenderScriptService.java
+Starting at line 76 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/MailSenderScriptService.java
+
+    public ScriptMimeMessage createMessage(String hint, Object source, Map<String, Object> parameters)
+    {
+        ScriptMimeMessage result;
+        try {
+            MimeMessageFactory<MimeMessage> factory = MimeMessageFactoryProvider.get(hint, MimeMessage.class,
+                this.componentManagerProvider.get());
+
+            MimeMessage message = factory.createMessage(source, parameters);
+            result = new ScriptMimeMessage(message, this.execution, this.componentManagerProvider.get());
+        } catch (Exception e) {
+            // No factory found, set an error
+            // An error occurred, save it and return null
+            setError(e);
+            return null;
+        }
+
+        return result;
+    }
+
+    /**
+     * Construct an iterator of Mime Messages by running the Component implementation of {@link
+     * org.xwiki.mail.MimeMessageFactory} corresponding to the passed hint.
+     *
+     * @param hint the component hint of a {@link org.xwiki.mail.MimeMessageFactory} component
+     * @param source the source from which to prefill the Mime Messages (depends on the implementation)
+     * @return the pre-filled Mime Message iterator
+     */
+    public Iterator<MimeMessage> createMessages(String hint, Object source)
+    {
+        return createMessages(hint, source, Collections.<String, Object>emptyMap());
+
+=====================================================================
+Found a 15 line (117 tokens) duplication in the following files: 
+Starting at line 122 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+Starting at line 267 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+
+    void watchWhenExclusiveFilter() throws Exception
+    {
+        // Mocks
+        WatchedEntityReference watchedEntityReference = mock(WatchedEntityReference.class);
+        DocumentReference userDocRef = new DocumentReference("xwiki", "XWiki", "User");
+        UserReference userRef = mock(UserReference.class);
+        when(this.userReferenceResolver.resolve(userDocRef)).thenReturn(userRef);
+        when(this.userReferenceSerializer.serialize(userRef)).thenReturn(userDocRef);
+
+        // Filters
+        DefaultNotificationFilterPreference pref1 = new DefaultNotificationFilterPreference();
+        pref1.setNotificationFormats(Sets.newSet(NotificationFormat.ALERT, NotificationFormat.EMAIL));
+        when(watchedEntityReference.matchExactly(pref1)).thenReturn(true);
+        pref1.setFilterType(NotificationFilterType.EXCLUSIVE);
+        pref1.setEnabled(true);
+
+=====================================================================
+Found a 20 line (117 tokens) duplication in the following files: 
+Starting at line 102 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/internal/AuthorizationManagerTest.java
+Starting at line 131 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/internal/AuthorizationManagerTest.java
+Starting at line 160 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/internal/AuthorizationManagerTest.java
+
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.LOGIN, user,
+            document, ctx);
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.VIEW, user,
+            document, ctx);
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.EDIT, user,
+            document, ctx);
+        assertAccessFalse("User from global wiki should have the same rights on empty subwiki", Right.DELETE, user,
+            document, ctx);
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.REGISTER, user,
+            document, ctx);
+        assertAccessTrue("User from global wiki should have the same rights on empty subwiki", Right.COMMENT, user,
+            document, ctx);
+        assertAccessFalse("User from global wiki should have the same rights on empty subwiki", Right.PROGRAM, user,
+            document, ctx);
+        assertAccessFalse("User from global wiki should have the same rights on empty subwiki", Right.ADMIN, user,
+            document, ctx);
+    }
+
+    @Test
+    public void testPublicAccessOnTopLevel() throws Exception
+
+=====================================================================
+Found a 20 line (117 tokens) duplication in the following files: 
+Starting at line 571 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-script/src/test/java/org/xwiki/wiki/user/script/WikiUserManagerScriptServiceTest.java
+Starting at line 597 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-script/src/test/java/org/xwiki/wiki/user/script/WikiUserManagerScriptServiceTest.java
+
+        MemberCandidacy candidacy = new MemberCandidacy("subwiki", "mainWiki:XWiki.OtherUser",
+                MemberCandidacy.CandidateType.REQUEST);
+        candidacy.setId(12);
+        when(this.wikiUserManager.getCandidacy("subwiki", candidacy.getId())).thenReturn(candidacy);
+
+        // The current user does not have ADMIN right
+        when(this.authorizationManager.hasAccess(ADMIN, USER_DOC_REF, new WikiReference("subwiki"))).thenReturn(false);
+
+        // Test
+        MemberCandidacy result = this.wikiUserManagerScriptService.getCandidacy("subwiki", 12);
+
+        // Asserts
+        assertNull(result);
+        Exception exception = this.wikiUserManagerScriptService.getLastError();
+        assertInstanceOf(WikiUserManagerScriptServiceException.class, exception);
+        assertEquals("You are not allowed to see this candidacy.", exception.getMessage());
+    }
+
+    @Test
+    void getCandidacyWhenGuest() throws Exception
+
+=====================================================================
+Found a 19 line (116 tokens) duplication in the following files: 
+Starting at line 781 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
+Starting at line 4141 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+
+    }
+
+    private String evaluate(String content, String name, VelocityContext vcontext, XWikiContext context)
+    {
+        StringWriter writer = new StringWriter();
+        try {
+            VelocityManager velocityManager = Utils.getComponent(VelocityManager.class);
+            velocityManager.getVelocityEngine().evaluate(vcontext, writer, name, content);
+            return writer.toString();
+        } catch (Exception e) {
+            LOGGER.error("Error while parsing velocity template namespace [{}]", name, e);
+            Object[] args = { name };
+            XWikiException xe =
+                new XWikiException(XWikiException.MODULE_XWIKI_RENDERING,
+                    XWikiException.ERROR_XWIKI_RENDERING_VELOCITY_EXCEPTION, "Error while parsing velocity page {0}",
+                    e, args);
+            return Util.getHTMLExceptionMessage(xe, context);
+        }
+    }
+
+=====================================================================
+Found a 13 line (116 tokens) duplication in the following files: 
+Starting at line 77 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 301 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 530 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        when(ldQuery.getLimit()).thenReturn(limit);
+        when(query.setOffset(offset.intValue())).thenReturn(query);
+        when(query.setLimit(limit)).thenReturn(query);
+
+        List<Object> expectedList = List.of(
+            mock(NotificationFilterPreference.class, "filterPref1"),
+            mock(NotificationFilterPreference.class, "filterPref2"),
+            mock(NotificationFilterPreference.class, "filterPref3")
+        );
+        when(query.execute()).thenReturn(expectedList);
+        assertEquals(expectedList, this.queryHelper.getFilterPreferences(ldQuery, owner, wikiReference));
+        verify(query).bindValue("owner", owner);
+        verify(query).setWiki(wikiName);
+
+=====================================================================
+Found a 15 line (116 tokens) duplication in the following files: 
+Starting at line 198 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/SaveActionTest.java
+Starting at line 276 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/SaveActionTest.java
+
+        when(mockForm.getTemplate()).thenReturn("");
+
+        assertFalse(saveAction.save(this.context));
+        assertEquals(Map.of("newVersion", "1.2"), saveAction.getJSONAnswer(context));
+
+        verify(mockAuthors).setOriginalMetadataAuthor(this.currentUserReference);
+        verify(mockAuthors).setEffectiveMetadataAuthor(this.effectiveAuthor);
+        verify(mockClonedDocument).setMetaDataDirty(true);
+        verify(this.xWiki).checkSavingDocument(USER_REFERENCE, mockClonedDocument, "My Changes", false, this.context);
+        verify(this.xWiki).saveDocument(mockClonedDocument, "My Changes", false, this.context);
+        verify(mockClonedDocument).removeLock(this.context);
+    }
+
+    @Test
+    void validSaveNewTranslation() throws Exception
+
+=====================================================================
+Found a 16 line (116 tokens) duplication in the following files: 
+Starting at line 168 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/DefaultAverageRatingTest.java
+Starting at line 202 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/DefaultAverageRatingTest.java
+
+    void removeVote()
+    {
+        DefaultAverageRating defaultAverageRank = new DefaultAverageRating("myId")
+            .setAverageVote(13.0f / 6)
+            .setTotalVote(6);
+        assertEquals("myId", defaultAverageRank.getId());
+        assertEquals(6, defaultAverageRank.getNbVotes());
+        assertEquals(2.166667, defaultAverageRank.getAverageVote(), 0.000001);
+
+        Date beforeFirstUpdate = new Date();
+        assertNotEquals(new Date(0), defaultAverageRank.getUpdatedAt());
+        assertNotNull(defaultAverageRank.getUpdatedAt());
+        assertTrue(beforeFirstUpdate.toInstant()
+            .isAfter(defaultAverageRank.getUpdatedAt().toInstant().minus(1, ChronoUnit.MINUTES)));
+
+        defaultAverageRank.removeRating(0);
+
+=====================================================================
+Found a 15 line (116 tokens) duplication in the following files: 
+Starting at line 62 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertiesResourceImpl.java
+Starting at line 62 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyResourceImpl.java
+
+    public Properties getClassProperties(String wikiName, String className) throws XWikiRestException
+    {
+        String database = Utils.getXWikiContext(componentManager).getWikiId();
+
+        try {
+            Utils.getXWikiContext(componentManager).setWikiId(wikiName);
+
+            DocumentReference classReference = this.resolver.resolve(className, new WikiReference(wikiName));
+            this.authorization.checkAccess(Right.VIEW, classReference);
+            com.xpn.xwiki.api.Class xwikiClass = Utils.getXWikiApi(componentManager).getClass(classReference);
+            if (xwikiClass == null) {
+                throw new WebApplicationException(Status.NOT_FOUND);
+            }
+
+            Class clazz = DomainObjectFactory.createClass(objectFactory, uriInfo.getBaseUri(), wikiName, xwikiClass);
+
+=====================================================================
+Found a 14 line (115 tokens) duplication in the following files: 
+Starting at line 388 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new StatusQueryCondition(USER_REFERENCE.toString(), true, false), conditions.next());
+
+=====================================================================
+Found a 14 line (115 tokens) duplication in the following files: 
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 515 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new StatusQueryCondition(USER_REFERENCE.toString(), null, false), conditions.next());
+
+=====================================================================
+Found a 9 line (115 tokens) duplication in the following files: 
+Starting at line 139 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 517 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+
+=====================================================================
+Found a 9 line (115 tokens) duplication in the following files: 
+Starting at line 152 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 165 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, ALERT_FORMAT));
+        assertEquals(OFF, notificationsUserProfilePage.getApplicationState(SYSTEM, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, ALERT_FORMAT));
+        assertEquals(OFF, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(OFF, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(OFF, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+
+=====================================================================
+Found a 9 line (115 tokens) duplication in the following files: 
+Starting at line 454 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 517 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+
+=====================================================================
+Found a 9 line (115 tokens) duplication in the following files: 
+Starting at line 482 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 517 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getApplicationState(SYSTEM, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+
+=====================================================================
+Found a 17 line (115 tokens) duplication in the following files: 
+Starting at line 1110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1147 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 1479 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void newDocumentWebHomeFromURLTemplateProviderSpecifiedButNotAllowed() throws Exception
+    {
+        // new document = xwiki:X.Y.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("X", "Y"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(true);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
+        String templateProviderFullName = "XWiki.MyTemplateProvider";
+        when(mockRequest.getParameter("templateprovider")).thenReturn(templateProviderFullName);
+
+        // Mock 1 existing template provider
+        mockExistingTemplateProviders(templateProviderFullName,
+            new DocumentReference("xwiki", Arrays.asList("XWiki"), "MyTemplateProvider"),
+
+=====================================================================
+Found a 16 line (115 tokens) duplication in the following files: 
+Starting at line 263 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/ModelFactoryTest.java
+Starting at line 302 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/ModelFactoryTest.java
+
+        when(this.emailAddressObfuscator.obfuscate(any(InternetAddress.class))).thenReturn(expectedEmail);
+
+        BaseObject xwikiObject = mock(BaseObject.class);
+        BaseClass xwikiClass = mock(BaseClass.class);
+
+        when(xwikiObject.getPropertyNames()).thenReturn(new String[] {});
+        when(xwikiObject.getXClass(this.xcontext)).thenReturn(xwikiClass);
+        when(xwikiObject.getClassName()).thenReturn("Some.XClass");
+        when(xwikiObject.getNumber()).thenReturn(0);
+
+        EmailClass emailField = new EmailClass();
+        emailField.setName("emailValue");
+        StringProperty emailElement = new StringProperty();
+        emailElement.setName("emailValue");
+        emailElement.setClassType("Password");
+        emailElement.setValue(inputMail);
+
+=====================================================================
+Found a 10 line (115 tokens) duplication in the following files: 
+Starting at line 718 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/WikisResourceIT.java
+Starting at line 765 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/WikisResourceIT.java
+
+                    buildURI(WikiSearchResource.class, getWiki())));
+            Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+            results = (SearchResults) this.unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+            Assert.assertEquals(1, results.getSearchResults().size());
+            Assert.assertEquals(ref2.getName(), results.getSearchResults().get(0).getPageName());
+        } finally {
+            this.testUtils.rest().delete(ref1);
+            this.testUtils.rest().delete(ref2);
+        }
+    }
+
+=====================================================================
+Found a 33 line (114 tokens) duplication in the following files: 
+Starting at line 47 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ColorThemePropertyDisplayerPage.java
+Starting at line 65 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ThemesAdministrationSectionPage.java
+
+        return new ColorThemePropertyDisplayerPage();
+    }
+
+    private List<WebElement> getColorThemeOptions()
+    {
+        return iconThemeInput.findElements(By.tagName("option"));
+    }
+
+    private List<WebElement> getColibriThemeOptions()
+    {
+        return iconThemeInput.findElements(By.xpath("//optgroup[@label='Colibri Themes']//option"));
+    }
+    private List<WebElement> getFlamingoThemeOptions()
+    {
+        return iconThemeInput.findElements(By.xpath("//optgroup[@label='Flamingo Themes']//option"));
+    }
+
+    /**
+     * @return the list of available color themes
+     */
+    public List<String> getColorThemes()
+    {
+        List<String> results = new ArrayList<>();
+        for (WebElement option : getColorThemeOptions()) {
+            results.add(option.getText());
+        }
+        return results;
+    }
+
+    /**
+     * @return the list of colibri themes
+     */
+    public List<String> getColibriColorThemes()
+
+=====================================================================
+Found a 29 line (114 tokens) duplication in the following files: 
+Starting at line 717 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test/xwiki-platform-invitation-test-docker/src/test/it/org/xwiki/invitation/test/docker/InvitationIT.java
+Starting at line 191 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-test/xwiki-platform-security-authentication-test-docker/src/test/it/org/xwiki/security/authentication/test/ui/ResetPasswordIT.java
+
+            messageMap.put("htmlPart", html.getContent().toString());
+        }
+
+        return messageMap;
+    }
+
+    private BodyPart getPart(Multipart messageContent, String mimeType) throws Exception
+    {
+        for (int i = 0; i < messageContent.getCount(); i++) {
+            BodyPart part = messageContent.getBodyPart(i);
+
+            if (part.isMimeType(mimeType)) {
+                return part;
+            }
+
+            if (part.isMimeType("multipart/related")
+                || part.isMimeType("multipart/alternative")
+                || part.isMimeType("multipart/mixed"))
+            {
+                BodyPart out = getPart((Multipart) part.getContent(), mimeType);
+                if (out != null) {
+                    return out;
+                }
+            }
+        }
+        return null;
+    }
+
+    private void startGreenMail()
+
+=====================================================================
+Found a 27 line (114 tokens) duplication in the following files: 
+Starting at line 42 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/AbstractXWikiAuthServiceWrapper.java
+Starting at line 57 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/StandardXWikiAuthServiceComponent.java
+
+    }
+
+    @Override
+    public XWikiUser checkAuth(XWikiContext context) throws XWikiException
+    {
+        return this.service.checkAuth(context);
+    }
+
+    @Override
+    public XWikiUser checkAuth(String username, String password, String rememberme, XWikiContext context)
+        throws XWikiException
+    {
+        return this.service.checkAuth(username, password, rememberme, context);
+    }
+
+    @Override
+    public void showLogin(XWikiContext context) throws XWikiException
+    {
+        this.service.showLogin(context);
+    }
+
+    @Override
+    public Principal authenticate(String username, String password, XWikiContext context) throws XWikiException
+    {
+        return this.service.authenticate(username, password, context);
+    }
+}
+
+=====================================================================
+Found a 12 line (114 tokens) duplication in the following files: 
+Starting at line 494 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+Starting at line 552 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+
+            + "Content of second section\n" + "1 Section 3\n" + "Content of section 3");
+        sections = this.document.getSections();
+        assertEquals(3, sections.size());
+        assertEquals("Section 1", sections.get(0).getSectionTitle());
+        assertEquals(
+            "1 Section 1\n" + "Content of first section\n" + "1.1 Subsection 2\n" + "Content of second section\n",
+            this.document.getContentOfSection(1));
+        assertEquals("1.1", sections.get(1).getSectionLevel());
+        assertEquals("1.1 Subsection 2\nContent of second section\n", this.document.getContentOfSection(2));
+        assertEquals(3, sections.get(2).getSectionNumber());
+        assertEquals(80, sections.get(2).getSectionIndex());
+        assertEquals("1 Section 3\nContent of section 3", this.document.getContentOfSection(3));
+
+=====================================================================
+Found a 19 line (114 tokens) duplication in the following files: 
+Starting at line 51 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentResourceImpl.java
+Starting at line 51 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentVersionResourceImpl.java
+
+            DocumentInfo documentInfo = getDocumentInfo(wikiName, spaceName, pageName, null, null, true, false);
+
+            Document doc = documentInfo.getDocument();
+
+            Vector<com.xpn.xwiki.api.Object> xwikiComments = doc.getComments();
+
+            for (com.xpn.xwiki.api.Object xwikiComment : xwikiComments) {
+                if (id.equals(xwikiComment.getNumber())) {
+                    return DomainObjectFactory.createComment(objectFactory, uriInfo.getBaseUri(), doc, xwikiComment,
+                            Utils.getXWikiApi(componentManager), withPrettyNames);
+                }
+            }
+
+            throw new WebApplicationException(Status.NOT_FOUND);
+        } catch (XWikiException e) {
+            throw new XWikiRestException(e);
+        }
+    }
+}
+
+=====================================================================
+Found a 20 line (114 tokens) duplication in the following files: 
+Starting at line 149 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/TagsResourceIT.java
+Starting at line 189 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/TagsResourceIT.java
+
+        Assert.assertEquals(getHttpMethodInfo(putMethod), HttpStatus.SC_ACCEPTED, putMethod.getStatusCode());
+
+        getMethod = executeGet(
+            buildURI(PageTagsResource.class, getWiki(), TestConstants.TEST_SPACE_NAME, TestConstants.TEST_PAGE_NAME)
+                .toString());
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Tags tags = (Tags) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+        boolean found = false;
+        for (Tag t : tags.getTags()) {
+            if (tagName.equals(t.getName())) {
+                found = true;
+                break;
+            }
+        }
+        Assert.assertTrue(found);
+    }
+
+    @Test
+    public void testPUTTagsFormUrlEncoded() throws Exception
+
+=====================================================================
+Found a 27 line (113 tokens) duplication in the following files: 
+Starting at line 717 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test/xwiki-platform-invitation-test-docker/src/test/it/org/xwiki/invitation/test/docker/InvitationIT.java
+Starting at line 127 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-test/xwiki-platform-security-authentication-test-docker/src/test/it/org/xwiki/security/authentication/test/ui/ForgotUsernameIT.java
+
+            messageMap.put("htmlPart", html.getContent().toString());
+        }
+
+        return messageMap;
+    }
+
+    private BodyPart getPart(Multipart messageContent, String mimeType) throws Exception
+    {
+        for (int i = 0; i < messageContent.getCount(); i++) {
+            BodyPart part = messageContent.getBodyPart(i);
+
+            if (part.isMimeType(mimeType)) {
+                return part;
+            }
+
+            if (part.isMimeType("multipart/related")
+                || part.isMimeType("multipart/alternative")
+                || part.isMimeType("multipart/mixed"))
+            {
+                BodyPart out = getPart((Multipart) part.getContent(), mimeType);
+                if (out != null) {
+                    return out;
+                }
+            }
+        }
+        return null;
+    }
+
+=====================================================================
+Found a 13 line (113 tokens) duplication in the following files: 
+Starting at line 373 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 450 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+    public void testVerifyMultipleObjectsPropertyNotChanged() throws XWikiException
+    {
+        XWikiDocument newDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+        XWikiDocument oldDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+
+        BaseObject newObj1 = newDoc.newObject(this.testClassName, this.context);
+        newObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject newObj2 = newDoc.newObject(this.testClassName, this.context);
+        newObj2.setStringValue(this.testPropertyName, "value2");
+
+        BaseObject oldObj1 = oldDoc.newObject(this.testClassName, this.context);
+        oldObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject oldObj2 = oldDoc.newObject(this.testClassName, this.context);
+
+=====================================================================
+Found a 13 line (113 tokens) duplication in the following files: 
+Starting at line 453 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+Starting at line 512 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+
+        dbListClassEditElement.setMetaProperty("displayType", "input");
+        classEditPage.clickSaveAndView();
+
+        // Create a few XObjects with multiple selections and no selections.
+        // First, first two options selected.
+        DocumentReference doc1Ref = new DocumentReference("Doc1", testReference.getLastSpaceReference());
+        testUtils.rest().addObject(doc1Ref, testUtils.serializeReference(testReference), "myList", "Option1|Option2");
+        // Second, third option selected.
+        DocumentReference doc2Ref = new DocumentReference("Doc2", testReference.getLastSpaceReference());
+        testUtils.rest().addObject(doc2Ref, testUtils.serializeReference(testReference), "myList", "Option3");
+        // Third, no option selected.
+        DocumentReference doc3Ref = new DocumentReference("Doc3", testReference.getLastSpaceReference());
+        testUtils.rest().addObject(doc3Ref, testUtils.serializeReference(testReference));
+
+=====================================================================
+Found a 12 line (113 tokens) duplication in the following files: 
+Starting at line 281 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 331 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 387 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 887 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        this.request.put("category/join_mode", "OR");
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+
+        renderPage();
+
+        verify(this.queryService)
+            .hql(", BaseObject as obj , StringProperty as prop_category, StringProperty prop_name  "
+
+=====================================================================
+Found a 15 line (113 tokens) duplication in the following files: 
+Starting at line 81 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitReferenceEntityReferenceResolverTest.java
+Starting at line 79 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringEntityReferenceResolverTest.java
+
+            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI))),
+            EntityType.DOCUMENT);
+
+        assertEquals("page", reference.getName());
+        assertEquals(EntityType.DOCUMENT, reference.getType());
+        assertEquals("space", reference.getParent().getName());
+        assertEquals(EntityType.SPACE, reference.getParent().getType());
+        assertEquals("wiki", reference.getParent().getParent().getName());
+        assertEquals(EntityType.WIKI, reference.getParent().getParent().getType());
+    }
+
+    @Test
+    public void resolveWithExplicitReferenceWithHoles()
+    {
+        EntityReference reference = this.resolver.resolve(new EntityReference("page", EntityType.DOCUMENT,
+
+=====================================================================
+Found a 20 line (112 tokens) duplication in the following files: 
+Starting at line 317 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+Starting at line 451 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+
+    void imageWithCaption(TestUtils setup, TestReference testReference) throws Exception
+    {
+        // Run the tests as a normal user. We make the user advanced only to enable the Edit drop down menu.
+        loginStandardUser(setup);
+        // Upload an attachment to test with.
+        String attachmentName = "image.gif";
+        AttachmentReference attachmentReference = new AttachmentReference(attachmentName, testReference);
+        ViewPage newPage = uploadAttachment(setup, testReference, attachmentName);
+
+        // Move to the WYSIWYG edition page.
+        WYSIWYGEditPage wysiwygEditPage = newPage.editWYSIWYG();
+        CKEditor editor = new CKEditor("content").waitToLoad();
+
+        // Insert a with caption and alignment to center.
+        ImageDialogSelectModal imageDialogSelectModal = editor.getToolBar().insertImage();
+        imageDialogSelectModal.switchToTreeTab().selectAttachment(attachmentReference);
+        ImageDialogEditModal imageDialogEditModal = imageDialogSelectModal.clickSelect();
+        imageDialogEditModal.switchToStandardTab().clickCaptionCheckbox();
+        imageDialogEditModal.switchToAdvancedTab().selectCenterAlignment();
+        imageDialogEditModal.clickInsert();
+
+=====================================================================
+Found a 25 line (112 tokens) duplication in the following files: 
+Starting at line 73 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-configuration/xwiki-platform-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractXWikiPreferencesConfigurationSource.java
+Starting at line 57 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/configuration/source/AbstractXClassConfigurationSource.java
+
+        return new DocumentReference(CLASS_REFERENCE.getName(), new SpaceReference(CLASS_SPACE_NAME,
+            getCurrentWikiReference()));
+    }
+
+    protected BaseObject getBaseObject(String language) throws XWikiException
+    {
+        XWikiContext xcontext = this.xcontextProvider.get();
+
+        if (xcontext != null && xcontext.getWiki() != null) {
+            DocumentReference documentReference = getFailsafeDocumentReference();
+            LocalDocumentReference classReference = getFailsafeClassReference();
+
+            if (documentReference != null && classReference != null) {
+                XWikiDocument document = xcontext.getWiki().getDocument(getDocumentReference(), xcontext);
+
+                return getBaseObject(document, language);
+            }
+        }
+
+        return null;
+    }
+
+    protected BaseObject getBaseObject(XWikiDocument document, String language)
+    {
+        if (language != null) {
+
+=====================================================================
+Found a 14 line (112 tokens) duplication in the following files: 
+Starting at line 118 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/GroupMessageStreamNotificationFilterTest.java
+Starting at line 141 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/GroupMessageStreamNotificationFilterTest.java
+
+    void filterEventUserNotInGroup(MockitoComponentManager rootComponentManager) throws Exception
+    {
+        Utils.setComponentManager(rootComponentManager);
+        ComponentManager componentManager =
+            rootComponentManager.registerMockComponent(ComponentManager.class, "context");
+        when(componentManager.getInstance(DocumentReferenceResolver.class, "currentmixed"))
+            .thenReturn(mock(DocumentReferenceResolver.class));
+
+        XWiki xWiki = mock(XWiki.class);
+        when(this.xWikiContext.getWiki()).thenReturn(xWiki);
+
+        User user = mock(User.class);
+        when(xWiki.getUser(USER, this.xWikiContext)).thenReturn(user);
+        when(user.isUserInGroup(GROUP_NAME)).thenReturn(false);
+
+=====================================================================
+Found a 12 line (112 tokens) duplication in the following files: 
+Starting at line 373 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 477 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+    public void testVerifyMultipleObjectsPropertyNotChanged() throws XWikiException
+    {
+        XWikiDocument newDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+        XWikiDocument oldDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+
+        BaseObject newObj1 = newDoc.newObject(this.testClassName, this.context);
+        newObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject newObj2 = newDoc.newObject(this.testClassName, this.context);
+        newObj2.setStringValue(this.testPropertyName, "value2");
+
+        BaseObject oldObj1 = oldDoc.newObject(this.testClassName, this.context);
+        oldObj1.setStringValue(this.testPropertyName, "value1");
+
+=====================================================================
+Found a 15 line (112 tokens) duplication in the following files: 
+Starting at line 50 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java
+Starting at line 79 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java
+
+            @QueryParam("blackList") String blackList,
+            @QueryParam("pages") String pages,
+            @QueryParam("spaces") String spaces,
+            @QueryParam("wikis") String wikis,
+            @QueryParam("users") String users,
+            @QueryParam("count") String count,
+            @QueryParam("displayOwnEvents") String displayOwnEvents,
+            @QueryParam("displayMinorEvents") String displayMinorEvents,
+            @QueryParam("displaySystemEvents") String displaySystemEvents,
+            @QueryParam("displayReadEvents") String displayReadEvents,
+            @QueryParam("displayReadStatus") String displayReadStatus,
+            @QueryParam("tags") String tags,
+            @QueryParam("currentWiki") String currentWiki,
+            @QueryParam("async") String async,
+            @QueryParam("asyncId") String asyncId,
+
+=====================================================================
+Found a 20 line (112 tokens) duplication in the following files: 
+Starting at line 3350 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+Starting at line 3452 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+
+                userPreferenceLanguage = userdoc.getStringValue("XWiki.XWikiUsers", "default_language");
+            }
+        } catch (XWikiException e) {
+        }
+
+        // Get navigator language setting
+        if (context.getRequest() != null) {
+            String accept = context.getRequest().getHeader("Accept-Language");
+            if ((accept != null) && (!accept.equals(""))) {
+                String[] alist = StringUtils.split(accept, ",;-");
+                if ((alist != null) && !(alist.length == 0)) {
+                    context.setLanguage(alist[0]);
+                    navigatorLanguage = alist[0];
+                }
+            }
+        }
+
+        // Get language from cookie
+        try {
+            cookieLanguage = Util.normalizeLanguage(getUserPreferenceFromCookie("language", context));
+
+=====================================================================
+Found a 12 line (112 tokens) duplication in the following files: 
+Starting at line 402 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/DocumentTest.java
+Starting at line 535 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/DocumentTest.java
+
+    {
+        XWikiDocument secureDocument = new XWikiDocument(new DocumentReference("xwiki", "Space", "Page"));
+        DocumentReference secureAuthor = new DocumentReference("wiki1", "XWiki", "secureAuthor");
+        secureDocument.setAuthorReference(secureAuthor);
+        DocumentReference secureContentAuthor = new DocumentReference("wiki1", "XWiki", "secureContentAuthor");
+        secureDocument.setContentAuthorReference(secureContentAuthor);
+        secureDocument.setCreatorReference(new DocumentReference("wiki1", "XWiki", "secureCreator"));
+        secureDocument.setEnforceRequiredRights(true);
+        if (StringUtils.isNotBlank(rightOnSecureDocument)) {
+            BaseObject requiredRightObject =
+                secureDocument.newXObject(DocumentRequiredRightsReader.CLASS_REFERENCE, this.oldcore.getXWikiContext());
+            requiredRightObject.setStringValue(DocumentRequiredRightsReader.PROPERTY_NAME, rightOnSecureDocument);
+
+=====================================================================
+Found a 12 line (112 tokens) duplication in the following files: 
+Starting at line 443 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 552 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void update() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a terminal document to another terminal document.
+        DocumentReference oldLinkTarget = new DocumentReference("wiki", "A", "B");
+
+=====================================================================
+Found a 13 line (112 tokens) duplication in the following files: 
+Starting at line 108 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/CommentsResourceIT.java
+Starting at line 132 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/CommentsResourceIT.java
+
+    public void testPOSTCommentWithTextPlain() throws Exception
+    {
+        String commentsUri = buildURI(CommentsResource.class, getWiki(), this.spaces, this.pageName).toString();
+
+        GetMethod getMethod = executeGet(commentsUri);
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Comments comments = (Comments) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+
+        int numberOfComments = comments.getComments().size();
+
+        PostMethod postMethod = executePost(commentsUri, "Comment", MediaType.TEXT_PLAIN,
+            TestUtils.SUPER_ADMIN_CREDENTIALS.getUserName(), TestUtils.SUPER_ADMIN_CREDENTIALS.getPassword());
+
+=====================================================================
+Found a 16 line (112 tokens) duplication in the following files: 
+Starting at line 164 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/NotificationMailDefaultHtmlTest.java
+Starting at line 376 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/NotificationMailDefaultHtmlTest.java
+
+            .thenReturn("Content");
+
+        when(this.iconManagerScriptService.renderHTML("file-text")).thenReturn("Icon file text");
+
+        String expectedDiffLink = "<a href='http://null:0/xwiki/bin/view/Test/?viewer=changes&#38;rev1=1.1&#38;"
+            + "rev2=2.1'>2.1</a>";
+        when(this.localizationScriptService.render("notifications.rss.seeChanges", List.of(expectedDiffLink)))
+            .thenReturn(String.format("See changes: [%s]", expectedDiffLink));
+
+        when(this.diffDisplayerScriptService.unified(any(String.class), any(String.class), isNull()))
+            .then(invocationOnMock -> {
+            String previous = invocationOnMock.getArgument(0);
+            assertEquals("", previous);
+
+            String next = invocationOnMock.getArgument(1);
+            assertEquals("Content", next);
+
+=====================================================================
+Found a 12 line (112 tokens) duplication in the following files: 
+Starting at line 165 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/internal/DefaultWebJarsUrlFactoryTest.java
+Starting at line 184 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/internal/DefaultWebJarsUrlFactoryTest.java
+
+        InstalledExtension extension = mock(InstalledExtension.class);
+        when(this.installedExtensionRepository.getInstalledExtension("org.webjars:angular", "wiki:math"))
+            .thenReturn(extension);
+        when(extension.getId()).thenReturn(new ExtensionId("angular", "2.1.11"));
+
+        WebJarsResourceReference resourceReference =
+            new WebJarsResourceReference("wiki:math", Arrays.asList("angular", "2.1.11", "angular.css"));
+        when(this.serializer.serialize(resourceReference))
+            .thenReturn(new ExtendedURL(Arrays.asList("xwiki", "angular", "2.1.11", "angular.css")));
+
+        assertEquals("/xwiki/angular/2.1.11/angular.css",
+            this.webJarsUrlFactory.url("angular", "angular.css", Collections.singletonMap("wiki", "math")));
+
+=====================================================================
+Found a 15 line (111 tokens) duplication in the following files: 
+Starting at line 118 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreNoLegacyTest.java
+Starting at line 162 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreTest.java
+
+        verify(this.store, times(2)).deleteEvent("id");
+    }
+
+    @Test
+    void getEvent() throws EventStreamException, QueryException
+    {
+        assertFalse(this.defaultStore.getEvent("id").isPresent());
+
+        when(this.store.getEvent("id")).thenReturn(Optional.of(EVENT));
+
+        assertSame(EVENT, this.defaultStore.getEvent("id").get());
+
+        when(this.store.getEvent("id")).thenReturn(Optional.empty());
+
+        assertFalse(this.defaultStore.getEvent("id").isPresent());
+
+=====================================================================
+Found a 12 line (111 tokens) duplication in the following files: 
+Starting at line 281 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 432 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 840 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 887 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 934 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 997 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        this.request.put("category/join_mode", "OR");
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+
+        renderPage();
+
+        verify(this.queryService)
+            .hql(", BaseObject as obj , StringProperty as prop_category, StringProperty prop_name  "
+
+=====================================================================
+Found a 12 line (111 tokens) duplication in the following files: 
+Starting at line 331 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 432 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 840 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 934 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 997 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        setJoinMode("category", "OR");
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+
+        renderPage();
+
+        verify(this.queryService)
+            .hql(", BaseObject as obj , StringListProperty as prop_category, StringProperty prop_name  "
+
+=====================================================================
+Found a 12 line (111 tokens) duplication in the following files: 
+Starting at line 387 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 432 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 840 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 934 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 997 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        this.request.put("category/join_mode", "OR");
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+
+        renderPage();
+
+        verify(this.queryService)
+            .hql(", BaseObject as obj , StringProperty as prop_category, StringProperty prop_name  "
+
+=====================================================================
+Found a 8 line (111 tokens) duplication in the following files: 
+Starting at line 460 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 488 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+    void nonViewableResultsAreObfuscated() throws Exception
+    {
+        this.request.put("limit", "2");
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(3L);
+
+=====================================================================
+Found a 6 line (111 tokens) duplication in the following files: 
+Starting at line 515 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 685 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 767 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 809 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+        when(this.query.execute()).thenReturn(Arrays.asList("XWiki.NotViewable"));
+
+=====================================================================
+Found a 14 line (111 tokens) duplication in the following files: 
+Starting at line 122 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+Starting at line 155 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+Starting at line 234 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+Starting at line 267 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+Starting at line 300 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesManagerTest.java
+
+    void watchWhenExclusiveFilter() throws Exception
+    {
+        // Mocks
+        WatchedEntityReference watchedEntityReference = mock(WatchedEntityReference.class);
+        DocumentReference userDocRef = new DocumentReference("xwiki", "XWiki", "User");
+        UserReference userRef = mock(UserReference.class);
+        when(this.userReferenceResolver.resolve(userDocRef)).thenReturn(userRef);
+        when(this.userReferenceSerializer.serialize(userRef)).thenReturn(userDocRef);
+
+        // Filters
+        DefaultNotificationFilterPreference pref1 = new DefaultNotificationFilterPreference();
+        pref1.setNotificationFormats(Sets.newSet(NotificationFormat.ALERT, NotificationFormat.EMAIL));
+        when(watchedEntityReference.matchExactly(pref1)).thenReturn(true);
+        pref1.setFilterType(NotificationFilterType.EXCLUSIVE);
+
+=====================================================================
+Found a 12 line (111 tokens) duplication in the following files: 
+Starting at line 552 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 720 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 822 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void renameAttachment() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a terminal document to another terminal document.
+        DocumentReference oldLinkTarget = new DocumentReference("wiki", "A", "B");
+
+=====================================================================
+Found a 17 line (111 tokens) duplication in the following files: 
+Starting at line 83 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/manager/DefaultWikiCreatorTest.java
+Starting at line 112 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/manager/DefaultWikiCreatorTest.java
+
+        when(wikiConfiguration.shouldCreateDatabase()).thenReturn(true);
+
+        // Other mocks
+        DefaultWikiDescriptor descriptor = new DefaultWikiDescriptor("wikiid1", "wikialias1", "owner");
+        XWikiDocument descriptorDocument = mock(XWikiDocument.class);
+        when(wikiDescriptorBuilder.save(eq(descriptor))).thenReturn(descriptorDocument);
+        when(wikiDescriptorManager.getById("wikiid1")).thenReturn(descriptor);
+        when(store.isWikiNameAvailable(any(String.class), any(XWikiContext.class))).thenReturn(true);
+
+        // Create
+        WikiDescriptor newWikiDescriptor = this.mocker.getComponentUnderTest().create("wikiid1", "wikialias1", "owner");
+        assertNotNull(newWikiDescriptor);
+
+        // Verify that the wiki descriptor is an instance of DefaultWikiDescriptor
+        assertTrue(newWikiDescriptor instanceof DefaultWikiDescriptor);
+        // Verify that the wiki has been created
+        verify(store).createWiki(eq("wikiid1"), any(XWikiContext.class));
+
+=====================================================================
+Found a 10 line (110 tokens) duplication in the following files: 
+Starting at line 163 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+Starting at line 112 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentRenderingTest.java
+
+        this.baseClass = this.document.getxWikiClass();
+        this.baseClass.addTextField("string", "String", 30);
+        this.baseClass.addTextAreaField("area", "Area", 10, 10);
+        this.baseClass.addTextAreaField("puretextarea", "Pure text area", 10, 10);
+        // set the text areas an non interpreted content
+        ((TextAreaClass) this.baseClass.getField("puretextarea")).setContentType("puretext");
+        this.baseClass.addPasswordField("passwd", "Password", 30);
+        this.baseClass.addBooleanField("boolean", "Boolean", "yesno");
+        this.baseClass.addNumberField("int", "Int", 10, "integer");
+        this.baseClass.addStaticListField("stringlist", "StringList", "value1, value2");
+
+=====================================================================
+Found a 11 line (110 tokens) duplication in the following files: 
+Starting at line 423 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 523 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+    public void testVerifyMultipleObjectsOtherObjectAdded() throws XWikiException
+    {
+        XWikiDocument newDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+        XWikiDocument oldDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+
+        BaseObject newObj1 = newDoc.newObject(this.testClassName, this.context);
+        newObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject newObjOtherClass = newDoc.newObject(this.otherClassName, this.context);
+        newObjOtherClass.setStringValue(this.testPropertyName, "value2");
+        BaseObject newObj2 = newDoc.newObject(this.testClassName, this.context);
+        newObj2.setStringValue(this.testPropertyName, "value2");
+
+=====================================================================
+Found a 10 line (110 tokens) duplication in the following files: 
+Starting at line 306 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+Starting at line 490 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+
+            buildMentionMacro(USER_U1, "anchor1", FIRST_NAME),
+            buildMentionMacro(USER_U1, "anchor2", FIRST_NAME));
+        when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
+
+        // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
+        Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
+        oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
+        when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
+        Map<MentionedActorReference, List<String>> newCounts = new HashMap<>();
+        newCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor1", "anchor2"));
+
+=====================================================================
+Found a 11 line (110 tokens) duplication in the following files: 
+Starting at line 364 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+Starting at line 490 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+
+            buildMentionMacro(USER_U1, "anchor1", FIRST_NAME),
+            buildMentionMacro(USER_U1, "anchor2", FIRST_NAME)
+        );
+        when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
+
+        // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
+        Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
+        oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
+        when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
+        Map<MentionedActorReference, List<String>> newCounts = new HashMap<>();
+        newCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor1", "anchor2"));
+
+=====================================================================
+Found a 20 line (110 tokens) duplication in the following files: 
+Starting at line 153 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
+Starting at line 95 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
+
+        property.setValue(nvalue);
+        return property;
+    }
+
+    @Override
+    public void displayEdit(StringBuffer buffer, String name, String prefix, BaseCollection object, XWikiContext context)
+    {
+        input input = new input();
+        input.setAttributeFilter(new XMLAttributeValueFilter());
+
+        BaseProperty prop = (BaseProperty) object.safeget(name);
+        if (prop != null) {
+            input.setValue(prop.toText());
+        }
+
+        input.setType("text");
+        input.setName(prefix + name);
+        input.setID(prefix + name);
+        input.setSize(getSize());
+        input.setDisabled(isDisabled());
+
+=====================================================================
+Found a 11 line (110 tokens) duplication in the following files: 
+Starting at line 238 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentArchiveTest.java
+Starting at line 272 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentArchiveTest.java
+
+        XWikiDocument doc11 = doc.clone();
+        
+        doc.setContent("content 2.1\nqwe @ ");
+        archive.updateArchive(doc, author, new Date(), "2.1", new Version(2,1), context);
+        
+        doc.setContent("content 2.2\nqweq@ ");
+        archive.updateArchive(doc, author, new Date(), "2.2", new Version(2,2), context);
+        
+        doc.setContent("content 2.3\nqweqe @@");
+        archive.updateArchive(doc, author, new Date(), "2.3", new Version(2,3), context);
+        assertEquals(new Version(2,3), archive.getLatestVersion());
+
+=====================================================================
+Found a 12 line (110 tokens) duplication in the following files: 
+Starting at line 443 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 596 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 656 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void update() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a terminal document to another terminal document.
+        DocumentReference oldLinkTarget = new DocumentReference("wiki", "A", "B");
+
+=====================================================================
+Found a 13 line (110 tokens) duplication in the following files: 
+Starting at line 136 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-context/src/test/java/org/xwiki/rendering/internal/macro/context/ContextMacroTest.java
+Starting at line 181 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-context/src/test/java/org/xwiki/rendering/internal/macro/context/ContextMacroTest.java
+
+    void executeWhenNoDocumentSpecified() throws Exception
+    {
+        MacroBlock macroBlock = new MacroBlock("context", Collections.<String, String>emptyMap(), false);
+        MetaData metadata = new MetaData();
+        metadata.addMetaData(MetaData.SOURCE, "source");
+        XDOM pageXDOM = new XDOM(Arrays.asList(macroBlock), metadata);
+        MacroTransformationContext macroContext = new MacroTransformationContext();
+        macroContext.setSyntax(Syntax.XWIKI_2_0);
+        macroContext.setCurrentMacroBlock(macroBlock);
+        macroContext.setXDOM(pageXDOM);
+
+        DocumentModelBridge dmb = mock(DocumentModelBridge.class);
+        when(this.dab.getTranslatedDocumentInstance(TARGET_REFERENCE)).thenReturn(dmb);
+
+=====================================================================
+Found a 16 line (110 tokens) duplication in the following files: 
+Starting at line 325 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+Starting at line 357 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+
+    void hasEditAndDefaultClassSheetReference() throws Exception
+    {
+        this.scriptContext.setAttribute("hasEdit", true, GLOBAL_SCOPE);
+
+        String pageName = "Page";
+        DocumentReference mainPageReference = new DocumentReference("xwiki", "Space", pageName);
+        XWikiDocument xwikiDocument = this.xwiki.getDocument(mainPageReference, this.context);
+        xwikiDocument.getXClass().addTextField("testField", "Test Field", 10);
+        this.xwiki.saveDocument(xwikiDocument, this.context);
+
+        // Create defaultClassSheetReference
+        XWikiDocument defaultClassSheet =
+            this.xwiki.getDocument(new DocumentReference("xwiki", "Space", "PageSheet"), this.context);
+        this.xwiki.saveDocument(defaultClassSheet, this.context);
+
+        XWikiDocument doc = loadPage(XWIKI_CLASS_SHEET);
+
+=====================================================================
+Found a 12 line (109 tokens) duplication in the following files: 
+Starting at line 216 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509KeyWikiStoreTest.java
+Starting at line 308 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509KeyWikiStoreTest.java
+
+    public void storingPrivateKeyToCertificateDocument() throws Exception
+    {
+        XWikiDocument storeDoc = mock(XWikiDocument.class);
+        when(xwiki.getDocument(new DocumentReference(WIKI, SPACE, DOCUMENT), xcontext)).thenReturn(storeDoc);
+
+        BaseObject certObj = mock(BaseObject.class);
+        when(storeDoc.getXObject(X509CertificateWikiStore.CERTIFICATECLASS, 0)).thenReturn(certObj);
+
+        when(query.<Object[]>execute()).thenReturn(Collections.singletonList(new Object[]{"space.document", 0}));
+
+        BaseObject pkObj = mock(BaseObject.class);
+        when(storeDoc.newXObject(X509KeyWikiStore.PRIVATEKEYCLASS, xcontext)).thenReturn(pkObj);
+
+=====================================================================
+Found a 12 line (109 tokens) duplication in the following files: 
+Starting at line 182 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/delete/DocumentsDeletingListenerTest.java
+Starting at line 225 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/job/XClassDeletingListenerTest.java
+Starting at line 264 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/job/XClassDeletingListenerTest.java
+
+    void onEventWhenCancelled() throws Exception
+    {
+        Request request = mock(Request.class);
+        Job job = mock(Job.class);
+        JobStatus status = mock(JobStatus.class);
+        when(job.getRequest()).thenReturn(request);
+        when(request.isInteractive()).thenReturn(true);
+        when(job.getStatus()).thenReturn(status);
+
+        Map<EntityReference, EntitySelection> concernedEntities = new HashMap<>();
+        DocumentReference doc1 = new DocumentReference("a", "b", "c1");
+        concernedEntities.put(doc1, new EntitySelection(doc1));
+
+=====================================================================
+Found a 11 line (109 tokens) duplication in the following files: 
+Starting at line 81 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/CreatedDocumentMentionsAnalyzerTest.java
+Starting at line 137 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/CreatedDocumentMentionsAnalyzerTest.java
+
+    void analyzeNoMentionFound()
+    {
+        XWikiDocument doc = mock(XWikiDocument.class);
+        when(doc.getSyntax()).thenReturn(XWIKI_2_1);
+        XDOM xdom = new XDOM(asList());
+        when(doc.getXDOM()).thenReturn(xdom);
+        when(this.xdomService.listMentionMacros(xdom)).thenReturn(asList());
+        when(this.xdomService.groupAnchorsByUserReference(asList())).thenReturn(new HashMap<>());
+
+        Map<DocumentReference, List<BaseObject>> mapBaseObjects = new HashMap<>();
+        BaseObject baseObject = new BaseObject();
+
+=====================================================================
+Found a 14 line (109 tokens) duplication in the following files: 
+Starting at line 428 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new StatusQueryCondition(null, true, false), conditions.next());
+
+=====================================================================
+Found a 13 line (109 tokens) duplication in the following files: 
+Starting at line 185 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/DeletedAttachment.java
+Starting at line 200 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/DeletedDocument.java
+
+            if (hasAdminRights()) {
+                waitdays = getXWikiContext().getWiki().Param("xwiki.store.recyclebin.adminWaitDays", "0");
+            } else {
+                waitdays = getXWikiContext().getWiki().Param("xwiki.store.recyclebin.waitDays", "7");
+            }
+            int seconds = (int) (Double.parseDouble(waitdays) * 24 * 60 * 60 + 0.5);
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(getDate());
+            cal.add(Calendar.SECOND, seconds);
+            return cal.before(Calendar.getInstance());
+        } catch (Exception ex) {
+            // Public APIs should not throw exceptions
+            LOGGER.warn("Exception while checking if entry [" + getId() + "] can be removed from the recycle bin", ex);
+
+=====================================================================
+Found a 10 line (109 tokens) duplication in the following files: 
+Starting at line 8045 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+Starting at line 8233 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+
+        String start = pref + LOCAL_REFERENCE_SERIALIZER.serialize(classReference) + "_";
+
+        for (String name : map.keySet()) {
+            if (name.startsWith(start)) {
+                int pos = name.indexOf('_', start.length() + 1);
+                String prefix = name.substring(0, pos);
+                int num = Integer.decode(prefix.substring(prefix.lastIndexOf('_') + 1)).intValue();
+                if (!objectsNumberDone.contains(Integer.valueOf(num))) {
+                    objectsNumberDone.add(Integer.valueOf(num));
+                    objects.add(addXObjectFromRequest(classReference, pref, num, context));
+
+=====================================================================
+Found a 12 line (109 tokens) duplication in the following files: 
+Starting at line 596 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 720 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 822 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void renameNonTerminalDocumentLinks() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a non-terminal document to another non-terminal document.
+        DocumentReference oldLinkTarget = new DocumentReference("wiki", "A", "WebHome");
+
+=====================================================================
+Found a 12 line (109 tokens) duplication in the following files: 
+Starting at line 656 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 720 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 822 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void renameNonTerminalToTerminalDocumentLinks() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a non-terminal document to a terminal document.
+        DocumentReference oldLinkTarget = new DocumentReference("wiki", "A", "WebHome");
+
+=====================================================================
+Found a 14 line (109 tokens) duplication in the following files: 
+Starting at line 440 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeManagerTest.java
+Starting at line 467 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeManagerTest.java
+
+            this.xobject.setStringValue("test", "");
+            this.xobject.setStringValue("previoustest", "previoustest");
+            this.previousDocument.addXObject(this.xobject);
+
+            BaseObject newobj = this.xobject.clone();
+            newobj.setStringValue("test", "test2");
+            newobj.setStringValue("newtest", "newtest");
+            this.nextDocument.addXObject(newobj);
+
+            MergeDocumentResult result = this.mergeManager.mergeDocument(this.previousDocument, this.nextDocument,
+                this.currentDocument, this.configuration);
+            List<LogEvent> logs = result.getLog().getLogs(LogLevel.ERROR);
+            // We get 2 logs: one for the change on existing property, one for the new property.
+            assertEquals(2, logs.size());
+
+=====================================================================
+Found a 17 line (109 tokens) duplication in the following files: 
+Starting at line 120 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+Starting at line 155 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+
+        XWikiDocument currentDocument = this.context.getDoc();
+        BaseObject baseObject = new BaseObject();
+        baseObject.setXClassReference(new DocumentReference("xwiki", "XWiki", "TagClass"));
+        baseObject.setStringListValue("tags", Arrays.asList("tag1", "tag2"));
+        currentDocument.addXObject(baseObject);
+        this.xwiki.saveDocument(currentDocument, this.context);
+
+        TemplateManager templateManager = this.oldcore.getMocker().getInstance(TemplateManager.class);
+        // Remove extra spaces to make it easy to assert the result below.
+        String result = templateManager.render("documentTags.vm").trim().replaceAll("\\s+", " ");
+
+        // Verify that the generated HTML matches the expectations:
+        // - The tag label is displayed
+        // - The tags after the tag label
+        // - No "+" link is displayed since the user doesn't have edit rights
+        assertThat(result, matchesPattern("\\Q<div class=\"doc-tags\" id=\"xdocTags\"> core.tags.list.label "
+            + "<span class=\"tag-wrapper\"> "
+
+=====================================================================
+Found a 11 line (108 tokens) duplication in the following files: 
+Starting at line 96 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamTest.java
+Starting at line 212 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamTest.java
+
+    void postPublicMessage() throws Exception
+    {
+        DefaultEvent t = new DefaultEvent();
+        t.setId("eid");
+        when(this.factory.createEvent()).thenReturn(t);
+        when(this.context.getCurrentEntityReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.bridge.getCurrentUserReference()).thenReturn(USER_DOCUMENT_REFERENCE);
+        when(this.serializer.serialize(USER_DOCUMENT_REFERENCE)).thenReturn(USER_REFERENCE);
+        CompletableFuture completableFuture = mock(CompletableFuture.class);
+        when(this.eventStore.saveEvent(t)).thenReturn(completableFuture);
+        this.defaultMessageStream.postPublicMessage(MESSAGE);
+
+=====================================================================
+Found a 19 line (108 tokens) duplication in the following files: 
+Starting at line 104 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 146 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+        XWikiDocument oldDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+
+        BaseObject oldObj = oldDoc.newObject(this.testClassName, this.context);
+        BaseObject newObj = newDoc.newObject(this.testClassName, this.context);
+
+        oldObj.setStringValue(this.testPropertyName, "value");
+        newObj.setStringValue(this.testPropertyName, "value");
+
+        this.passed = false;
+        this.rule.verify(newDoc, oldDoc, this.context);
+        assertFalse("My notification should not have been called", this.passed);
+
+        // The rule should be symmetric. Do the inverse test too
+        this.passed = false;
+        this.rule.verify(oldDoc, newDoc, this.context);
+        assertFalse("My notification should not have been called", this.passed);
+    }
+
+    public void testVerifySingleObjectChanged() throws XWikiException
+
+=====================================================================
+Found a 19 line (108 tokens) duplication in the following files: 
+Starting at line 125 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 217 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+        XWikiDocument oldDoc = new XWikiDocument(new DocumentReference("Test", "Test", "TestDoc"));
+
+        BaseObject oldObj = oldDoc.newObject(this.testClassName, this.context);
+        BaseObject newObj = newDoc.newObject(this.testClassName, this.context);
+
+        oldObj.setStringValue(this.testPropertyName, "value1");
+        newObj.setStringValue(this.testPropertyName, "value2");
+
+        this.passed = false;
+        this.rule.verify(newDoc, oldDoc, this.context);
+        assertTrue("My notification should have been called", this.passed);
+
+        // The rule should be symmetric. Do the inverse test too.
+        this.passed = false;
+        this.rule.verify(oldDoc, newDoc, this.context);
+        assertTrue("My notification should have been called", this.passed);
+    }
+
+    public void testVerifySingleObjectXWikiClassNotChanged() throws XWikiException
+
+=====================================================================
+Found a 18 line (108 tokens) duplication in the following files: 
+Starting at line 506 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 533 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 558 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+        newObj1.setStringValue(this.testPropertyName, "value1");
+
+        BaseObject oldObj1 = oldDoc.newObject(this.testClassName, this.context);
+        oldObj1.setStringValue(this.testPropertyName, "value1");
+        BaseObject oldObj2 = oldDoc.newObject(this.testClassName, this.context);
+        oldObj2.setStringValue(this.testPropertyName, "value2");
+
+        this.passed = false;
+        this.rule.verify(newDoc, oldDoc, this.context);
+        assertTrue("My notification should have been called", this.passed);
+
+        // The rule should be symmetric. Do the inverse test too.
+        this.passed = false;
+        this.rule.verify(oldDoc, newDoc, this.context);
+        assertTrue("My notification should have been called", this.passed);
+    }
+
+    public void testVerifyMultipleObjectsOtherObjectAddedPropertyChanged() throws XWikiException
+
+=====================================================================
+Found a 15 line (108 tokens) duplication in the following files: 
+Starting at line 270 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterTest.java
+Starting at line 408 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterTest.java
+
+        when(prefζ.getStartingDate()).thenReturn(new Date(99000));
+
+        Collection<NotificationFilterPreference> filterPreferences = Sets.newSet(prefγ, prefζ);
+
+        DocumentReference user = new DocumentReference("xwiki", "XWiki", "User");
+
+        // Test 1
+        String result = this.scopeNotificationFilter.filterExpression(user, filterPreferences, preference).toString();
+        assertEquals("((WIKI = \"wikiA\" AND SPACE STARTS WITH \"wikiA:SpaceB\") "
+                + "AND DATE >= \""+ new Date(0).toString() + "\")", result);
+
+        // Test with wikiA:SpaceE (filtered by γ & ζ)
+        Event event1 = mock(Event.class);
+        when(event1.getSpace()).thenReturn(new SpaceReference("SpaceE", wikiReference));
+        when(event1.getDate()).thenReturn(new Date(100000));
+
+=====================================================================
+Found a 15 line (108 tokens) duplication in the following files: 
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/UserEventManagerTest.java
+Starting at line 243 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/UserEventManagerTest.java
+
+        when(this.entityReferenceSerializer.serialize(userReference)).thenReturn("xwiki:User.Foo");
+
+        // the user can see the the document referenced in the event
+        DocumentReference eventDocumentReference = new DocumentReference("xwiki", "Foo", "Doc");
+        when(event.getDocument()).thenReturn(eventDocumentReference);
+        when(this.authorizationManager.hasAccess(Right.VIEW, userReference, eventDocumentReference)).thenReturn(true);
+
+        when(event.getDate()).thenReturn(new Date(42));
+
+        // the user has been created before the event was sent
+        DocumentModelBridge userDoc = mock(DocumentModelBridge.class);
+        when(this.documentAccessBridge.getDocumentInstance(userReference)).thenReturn(userDoc);
+        when(userDoc.getCreationDate()).thenReturn(new Date(40));
+
+        NotificationPreference pref1 = mock(NotificationPreference.class);
+
+=====================================================================
+Found a 11 line (108 tokens) duplication in the following files: 
+Starting at line 551 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 581 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, ADD_COMMENT, EMAIL_FORMAT));
+        assertEquals(OFF, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, EMAIL_FORMAT));
+
+        // We didn't change the email settings value in first step, so we obtain here the global settings until
+        // the user decide which settings she'd want for herself.
+        assertEquals(NotificationsUserProfilePage.EmailDiffType.NOTHING,
+
+=====================================================================
+Found a 16 line (108 tokens) duplication in the following files: 
+Starting at line 47 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-test/xwiki-platform-observation-test-tests/src/test/it/org/xwiki/cluster/test/DocumentCacheIT.java
+Starting at line 80 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-test/xwiki-platform-observation-test-tests/src/test/it/org/xwiki/cluster/test/DocumentCacheIT.java
+
+    public void documentModifiedCacheSync() throws Exception
+    {
+        Page page = new Page();
+        page.setSpace(TEST_SPACE);
+        page.setName("CacheSync");
+
+        LocalDocumentReference documentReference = new LocalDocumentReference(page.getSpace(), page.getName());
+
+        // 1) Edit a page on XWiki 0
+        AbstractTest.getUtil().switchExecutor(0);
+        page.setContent("content");
+        AbstractTest.getUtil().rest().save(page);
+        assertEquals("content", AbstractTest.getUtil().rest().<Page>get(documentReference).getContent());
+
+        // 2) Modify content of the page on XWiki 1
+        AbstractTest.getUtil().switchExecutor(1);
+
+=====================================================================
+Found a 22 line (108 tokens) duplication in the following files: 
+Starting at line 47 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiDefaultStore.java
+Starting at line 3181 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+
+        return searchDocuments(wheresql, true, 0, 0, context);
+    }
+
+    @Override
+    public List<XWikiDocument> searchDocuments(String wheresql, boolean distinctbylanguage, XWikiContext context)
+        throws XWikiException
+    {
+        return searchDocuments(wheresql, distinctbylanguage, 0, 0, context);
+    }
+
+    @Override
+    public List<XWikiDocument> searchDocuments(String wheresql, boolean distinctbylanguage, boolean customMapping,
+        XWikiContext context) throws XWikiException
+    {
+        return searchDocuments(wheresql, distinctbylanguage, customMapping, 0, 0, context);
+    }
+
+    @Override
+    public List<XWikiDocument> searchDocuments(String wheresql, int nb, int start, XWikiContext context)
+        throws XWikiException
+    {
+        return searchDocuments(wheresql, true, nb, start, context);
+
+=====================================================================
+Found a 16 line (108 tokens) duplication in the following files: 
+Starting at line 167 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/internal/DefaultRequestFactoryTest.java
+Starting at line 188 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/internal/DefaultRequestFactoryTest.java
+
+        MoveRequest renameRequest = requestFactory.createRenameRequest(source, destination);
+        
+        assertEquals(Arrays.asList(source), renameRequest.getEntityReferences());
+        assertEquals(destination, renameRequest.getDestination());
+        assertEquals(Arrays.asList(RefactoringJobs.GROUP, "rename"), renameRequest.getId().subList(0, 2));
+        assertFalse(renameRequest.isDeep());
+        assertTrue(renameRequest.isDeleteSource());
+        assertTrue(renameRequest.isUpdateLinks());
+        assertTrue(renameRequest.isUpdateParentField());
+        assertTrue(renameRequest.isAutoRedirect());
+        assertFalse(renameRequest.isInteractive());
+        assertCheckRights(renameRequest);
+    }
+
+    @Test
+    void createRenameRequestString()
+
+=====================================================================
+Found a 25 line (108 tokens) duplication in the following files: 
+Starting at line 58 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/AttachmentsResourceIT.java
+Starting at line 55 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+
+public class AttachmentsResourceIT extends AbstractHttpIT
+{
+    private String wikiName;
+
+    private List<String> spaces;
+
+    private String pageName;
+
+    private DocumentReference reference;
+
+    @Before
+    @Override
+    public void setUp() throws Exception
+    {
+        super.setUp();
+
+        this.wikiName = getWiki();
+        this.spaces = Arrays.asList(getTestClassName());
+        this.pageName = getTestMethodName();
+
+        this.reference = new DocumentReference(this.wikiName, this.spaces, this.pageName);
+
+        // Create a clean test page.
+        this.testUtils.rest().delete(this.reference);
+        this.testUtils.rest().savePage(this.reference);
+
+=====================================================================
+Found a 11 line (108 tokens) duplication in the following files: 
+Starting at line 246 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+Starting at line 466 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/ObjectsResourceIT.java
+
+    public void testPUTObjectUnauthorized() throws Exception
+    {
+        final String TAG_VALUE = UUID.randomUUID().toString();
+
+        Object objectToBePut = createObjectIfDoesNotExists("XWiki.TagClass", this.spaces, this.pageName);
+
+        GetMethod getMethod = executeGet(buildURI(ObjectResource.class, getWiki(), this.spaces, this.pageName,
+            objectToBePut.getClassName(), objectToBePut.getNumber()).toString());
+        Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_OK, getMethod.getStatusCode());
+
+        Object object = (Object) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+
+=====================================================================
+Found a 14 line (108 tokens) duplication in the following files: 
+Starting at line 80 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/descriptor/listener/WikiDescriptorListenerTest.java
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/descriptor/listener/WikiDescriptorListenerTest.java
+
+        Event event = new DocumentDeletedEvent();
+
+        List<BaseObject> objects = new ArrayList<>();
+        BaseObject object = mock(BaseObject.class);
+        objects.add(object);
+        when(originalDocument.getXObjects(WikiDescriptorListener.SERVER_CLASS)).thenReturn(objects);
+
+        DocumentReference documentReference = new DocumentReference("mainWiki", "XWiki", "XWikiServerSubwikiA");
+        when(originalDocument.getDocumentReference()).thenReturn(documentReference);
+
+        when(wikiDescriptorDocumentHelper.getWikiIdFromDocumentReference(documentReference)).thenReturn("subwikia");
+
+        DefaultWikiDescriptor descriptor = new DefaultWikiDescriptor("subwikia", "alias");
+        when(cache.getFromId("subwikia")).thenReturn(descriptor);
+
+=====================================================================
+Found a 17 line (107 tokens) duplication in the following files: 
+Starting at line 718 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-tests/src/test/java/org/xwiki/test/ui/extension/ExtensionIT.java
+Starting at line 775 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-tests/src/test/java/org/xwiki/test/ui/extension/ExtensionIT.java
+
+    public void testUpgrade() throws Exception
+    {
+        // Setup the extension.
+        String extensionId = "alice-xar-extension";
+        String oldVersion = "1.3";
+        String newVersion = "2.1.4";
+        TestExtension oldExtension =
+            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, oldVersion), "xar");
+        getRepositoryTestUtils().addExtension(oldExtension);
+        TestExtension newExtension =
+            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, newVersion), "xar");
+        getRepositoryTestUtils().attachFile(newExtension);
+        getRepositoryTestUtils().addVersionObject(newExtension, newVersion,
+            "attach:" + newExtension.getFile().getName());
+
+        // Make sure the old version is installed.
+        getExtensionTestUtils().install(new ExtensionId(extensionId, oldVersion));
+
+=====================================================================
+Found a 9 line (107 tokens) duplication in the following files: 
+Starting at line 283 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/test/java/org/xwiki/invitation/InvitationCommonPageTest.java
+Starting at line 88 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/test/java/org/xwiki/invitation/InvitationConfigPageTest.java
+
+            invitationCommonDocument.getObject("xwiki:Invitation.WebHome").getProperty("subjectLineTemplate")
+                .getValue());
+        this.oldcore.getScriptContext().setAttribute("subjectLine", "{{noscript/}}", GLOBAL_SCOPE);
+        com.xpn.xwiki.api.Document testDocument = new com.xpn.xwiki.api.Document(
+            this.xwiki.getDocument(new DocumentReference("xwiki", "Space", "Test"), this.context), this.context);
+        String renderedContent = testDocument.getRenderedContent(value, XWIKI_2_0.toIdString(), PLAIN_1_0.toIdString());
+        assertEquals("xe.invitation.emailContent.subjectLine [XWikiGuest, null, {{noscript/}}]", renderedContent);
+    }
+}
+
+=====================================================================
+Found a 11 line (107 tokens) duplication in the following files: 
+Starting at line 148 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+Starting at line 229 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+Starting at line 309 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+Starting at line 389 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+
+    void getPageWatchStatusPage() throws Exception
+    {
+        DocumentReference userDocReference = new DocumentReference("xwiki", "XWiki", "User");
+        when(this.context.getUserReference()).thenReturn(userDocReference);
+        UserReference userReference = mock(UserReference.class);
+        when(this.userReferenceResolver.resolve(userDocReference)).thenReturn(userReference);
+        String wikiName = "fooWiki";
+        DocumentReference documentReference = new DocumentReference(wikiName, List.of("Foo", "Bar", "Space"), "MYDoc");
+        WatchedLocationReference watchedLocationReference = mock(WatchedLocationReference.class);
+        when(this.watchedEntityFactory.createWatchedLocationReference(documentReference))
+            .thenReturn(watchedLocationReference);
+
+=====================================================================
+Found a 14 line (107 tokens) duplication in the following files: 
+Starting at line 84 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_HIDDEN, true, CompareType.EQUALS, true), conditions.next());
+
+=====================================================================
+Found a 14 line (107 tokens) duplication in the following files: 
+Starting at line 147 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, untilDate, CompareType.LESS_OR_EQUALS, false),
+
+=====================================================================
+Found a 14 line (107 tokens) duplication in the following files: 
+Starting at line 212 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_HIDDEN, true, CompareType.EQUALS, true), conditions.next());
+
+=====================================================================
+Found a 14 line (107 tokens) duplication in the following files: 
+Starting at line 264 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_DOCUMENT, "someValue1", CompareType.EQUALS, false),
+
+=====================================================================
+Found a 14 line (107 tokens) duplication in the following files: 
+Starting at line 308 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new InQueryCondition(true, Event.FIELD_ID, Arrays.asList("event1", "event2")), conditions.next());
+
+=====================================================================
+Found a 10 line (107 tokens) duplication in the following files: 
+Starting at line 458 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 582 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, EMAIL_FORMAT));
+
+        assertEquals(NotificationsUserProfilePage.EmailDiffType.STANDARD,
+            notificationsUserProfilePage.getNotificationEmailDiffType());
+        assertEquals(NotificationsUserProfilePage.AutowatchMode.MAJOR,
+
+=====================================================================
+Found a 10 line (107 tokens) duplication in the following files: 
+Starting at line 486 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+Starting at line 582 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, CREATE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, DELETE, EMAIL_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, ALERT_FORMAT));
+        assertEquals(ON, notificationsUserProfilePage.getEventTypeState(SYSTEM, UPDATE, EMAIL_FORMAT));
+
+        assertEquals(NotificationsUserProfilePage.EmailDiffType.STANDARD,
+            notificationsUserProfilePage.getNotificationEmailDiffType());
+        assertEquals(NotificationsUserProfilePage.AutowatchMode.MAJOR,
+
+=====================================================================
+Found a 14 line (107 tokens) duplication in the following files: 
+Starting at line 432 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/plugin/rightsmanager/ReferenceUserIteratorTest.java
+Starting at line 459 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/plugin/rightsmanager/ReferenceUserIteratorTest.java
+
+    public void getMembersWhenNestedGroup() throws Exception
+    {
+        setUpBaseMocks();
+        DocumentReference groupReference1 = new DocumentReference("groupwiki", "XWiki", "grouppage1");
+        DocumentReference userReference1 = new DocumentReference("userwiki", "XWiki", "user1");
+        DocumentReference userReference2 = new DocumentReference("userwiki", "XWiki", "user2");
+        DocumentReference groupReference2 = new DocumentReference("groupwiki", "XWiki", "grouppage2");
+        DocumentReference userReference3 = new DocumentReference("userwiki", "XWiki", "user3");
+        DocumentReference userReference4 = new DocumentReference("userwiki", "XWiki", "user4");
+        setUpGroupPageMocks(groupReference1, userReference1, userReference2, groupReference2);
+        setUpGroupPageMocks(groupReference2, userReference3, userReference4);
+
+        Iterator<DocumentReference> iterator =
+            new ReferenceUserIterator(groupReference1, this.resolver, this.execution);
+
+=====================================================================
+Found a 16 line (107 tokens) duplication in the following files: 
+Starting at line 88 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageHistoryResourceImpl.java
+Starting at line 89 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationHistoryResourceImpl.java
+
+                .setLimit(validateAndGetLimit(number))
+                .setOffset(start)
+                .setWiki(wikiName)
+                .execute();
+
+            for (Object object : queryResult) {
+                Object[] fields = (Object[]) object;
+
+                XWikiRCSNodeId nodeId = (XWikiRCSNodeId) fields[2];
+                Timestamp timestamp = (Timestamp) fields[3];
+                Date modified = new Date(timestamp.getTime());
+                String modifier = (String) fields[4];
+                String comment = (String) fields[5];
+
+                HistorySummary historySummary = DomainObjectFactory.createHistorySummary(objectFactory,
+                        uriInfo.getBaseUri(), wikiName, spaces, pageName, null, nodeId.getVersion(), modifier,
+
+=====================================================================
+Found a 8 line (107 tokens) duplication in the following files: 
+Starting at line 143 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/test/java/org/xwiki/user/script/GroupScriptServiceTest.java
+Starting at line 175 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/test/java/org/xwiki/user/script/GroupScriptServiceTest.java
+
+        when(this.groupManager.getMembers(groupA, false)).thenReturn(singletonList(groupB));
+        when(this.groupManager.getMembers(groupA, true)).thenReturn(asList(groupB, groupC));
+
+        when(this.groupManager.getMembers(groupB, false)).thenReturn(singletonList(groupC));
+        when(this.groupManager.getMembers(groupB, true)).thenReturn(singletonList(groupC));
+
+        when(this.groupManager.getMembers(groupC, false)).thenReturn(emptyList());
+        when(this.groupManager.getMembers(groupC, true)).thenReturn(emptyList());
+
+=====================================================================
+Found a 55 line (106 tokens) duplication in the following files: 
+Starting at line 224 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-document/src/main/java/org/xwiki/filter/instance/input/DocumentInstanceInputProperties.java
+Starting at line 113 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-extension/src/main/java/org/xwiki/filter/instance/input/ExtensionInstanceInputProperties.java
+
+    }
+
+    /**
+     * @return Indicate if events should be generated for classes
+     */
+    @PropertyName("With classes")
+    @PropertyDescription("Indicate if events should be generated for classes")
+    public boolean isWithWikiClass()
+    {
+        return this.withWikiClass;
+    }
+
+    /**
+     * @param withWikiClass Indicate if events should be generated for classes
+     */
+    public void setWithWikiClass(boolean withWikiClass)
+    {
+        this.withWikiClass = withWikiClass;
+    }
+
+    /**
+     * @return Indicate if events should be generated for objects
+     */
+    @PropertyName("With objects")
+    @PropertyDescription("Indicate if events should be generated for objects")
+    public boolean isWithWikiObjects()
+    {
+        return this.withWikiObjects;
+    }
+
+    /**
+     * @param withWikiObjects Indicate if events should be generated for objects
+     */
+    public void setWithWikiObjects(boolean withWikiObjects)
+    {
+        this.withWikiObjects = withWikiObjects;
+    }
+
+    /**
+     * @return Indicate if events should be generated for document content as HTML
+     */
+    @PropertyName("With content as HTML")
+    @PropertyDescription("Indicate if events should be generated for document content as HTML")
+    public boolean isWithWikiDocumentContentHTML()
+    {
+        return this.withWikiDocumentContentHTML;
+    }
+
+    /**
+     * @param withWikiDocumentContentHTML Indicate if events should be generated for document content as HTML
+     */
+    public void setWithWikiDocumentContentHTML(boolean withWikiDocumentContentHTML)
+    {
+        this.withWikiDocumentContentHTML = withWikiDocumentContentHTML;
+    }
+
+=====================================================================
+Found a 20 line (106 tokens) duplication in the following files: 
+Starting at line 64 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-notifications/src/test/java/org/xwiki/like/templates/RssLikeRecordableEventPageTest.java
+Starting at line 64 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/test/java/org/xwiki/mentions/templates/RssMentionPageTest.java
+
+    private TemplateManager templateManager;
+
+    private ScriptContext scriptContext;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        this.scriptContext = this.oldcore.getMocker().<ScriptContextManager>getInstance(ScriptContextManager.class)
+            .getCurrentScriptContext();
+        this.templateManager = this.oldcore.getMocker().getInstance(TemplateManager.class);
+    }
+
+    @Test
+    void htmlEscaping() throws Exception
+    {
+        // Create two versions of a document.
+        XWikiDocument testDocument = new XWikiDocument(TEST_DOCUMENT_REFERENCE);
+        testDocument.setTitle("Hello & Co");
+        testDocument.setSyntax(Syntax.XWIKI_2_1);
+        this.oldcore.getSpyXWiki().saveDocument(testDocument, this.context);
+
+=====================================================================
+Found a 11 line (106 tokens) duplication in the following files: 
+Starting at line 68 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+Starting at line 101 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersQueryHelperTest.java
+
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery(queryString, Query.HQL)).thenReturn(query);
+        when(query.bindValue("owner", owner)).thenReturn(query);
+        when(query.setWiki(wikiName)).thenReturn(query);
+        Long offset = 3L;
+        int limit = 12;
+
+        LiveDataQuery ldQuery = mock(LiveDataQuery.class);
+        when(ldQuery.getOffset()).thenReturn(offset);
+        when(ldQuery.getLimit()).thenReturn(limit);
+        when(query.setOffset(offset.intValue())).thenReturn(query);
+
+=====================================================================
+Found a 24 line (106 tokens) duplication in the following files: 
+Starting at line 262 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventManager.java
+Starting at line 230 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailEventFilter.java
+
+            && event.getUser().equals(this.referenceResolver.resolve(filterPreference.getUser()));
+    }
+
+    private boolean matchFormat(NotificationFilterPreference filterPreference, NotificationFormat format)
+    {
+        return format == null || filterPreference.getNotificationFormats().contains(format);
+    }
+
+    private boolean matchFilter(NotificationFilterPreference pref)
+    {
+        return pref.isEnabled() && EventUserFilter.FILTER_NAME.equals(pref.getFilterName());
+    }
+
+    private boolean matchFilterType(NotificationFilterPreference pref, NotificationFilterType filterType)
+    {
+        return pref.getFilterType() == filterType;
+    }
+
+    private boolean matchAllEvents(NotificationFilterPreference filterPreference)
+    {
+        // When the list of event types concerned by the filter is empty, we consider that the filter concerns
+        // all events.
+        return filterPreference.getEventTypes().isEmpty();
+    }
+
+=====================================================================
+Found a 20 line (106 tokens) duplication in the following files: 
+Starting at line 1024 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManager.java
+Starting at line 1174 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManager.java
+
+    public void removeUserOrGroupFromAllRights(String userOrGroupWiki, String userOrGroupSpace, String userOrGroupName,
+        boolean user, XWikiContext context) throws XWikiException
+    {
+        List<String> parameterValues = new ArrayList<>();
+
+        String fieldName;
+        if (user) {
+            fieldName = RIGHTSFIELD_USERS;
+        } else {
+            fieldName = RIGHTSFIELD_GROUPS;
+        }
+
+        BaseClass rightClass = context.getWiki().getRightsClass(context);
+        BaseClass globalRightClass = context.getWiki().getGlobalRightsClass(context);
+
+        String fieldTypeName = ((PropertyClass) rightClass.get(fieldName)).newProperty().getClass().getSimpleName();
+
+        String where = String.format(ALL_RIGHTS_QUERY, fieldTypeName);
+
+        parameterValues.add(rightClass.getName());
+
+=====================================================================
+Found a 11 line (106 tokens) duplication in the following files: 
+Starting at line 298 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/plugin/rightsmanager/ReferenceUserIteratorTest.java
+Starting at line 338 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/plugin/rightsmanager/ReferenceUserIteratorTest.java
+Starting at line 394 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/plugin/rightsmanager/ReferenceUserIteratorTest.java
+
+    public void getMembersWhenGroupWithOneBlankUser() throws Exception
+    {
+        setUpBaseMocks();
+        DocumentReference groupReference = new DocumentReference("groupwiki", "XWiki", "grouppage");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.isNew()).thenReturn(false);
+        when(document.getDocumentReference()).thenReturn(groupReference);
+        when(xwiki.getDocument(groupReference, this.xwikiContext)).thenReturn(document);
+        List<BaseObject> memberObjects = new ArrayList<>();
+        BaseObject bo = mock(BaseObject.class);
+        when(bo.getStringValue("member")).thenReturn("");
+
+=====================================================================
+Found a 15 line (106 tokens) duplication in the following files: 
+Starting at line 113 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/ActionFilterTest.java
+Starting at line 135 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/ActionFilterTest.java
+
+        when(request.getParameterValues("xaction")).thenReturn(null);
+        when(request.getParameterNames()).thenReturn(enumeration(singletonList("action_a")));
+        when(request.getRequestURI()).thenReturn("/segment1/segment2/segment3/");
+        when(request.getServletPath()).thenReturn("/serv");
+        when(request.getContextPath()).thenReturn("/ctx/");
+
+        this.filter.doFilter(request, response, chain);
+
+        verify(request).getParameterValues("xaction");
+        verify(chain).doFilter(request, response);
+        verify(request).getRequestDispatcher(any());
+    }
+
+    @Test
+    void doFilterXactionIsAction() throws Exception
+
+=====================================================================
+Found a 13 line (106 tokens) duplication in the following files: 
+Starting at line 79 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-signature/src/test/java/org/xwiki/rendering/signature/internal/MacroBlockSignatureGeneratorTest.java
+Starting at line 83 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-signature/src/test/java/org/xwiki/rendering/signature/internal/MacroBlockSignatureVerifierTest.java
+
+        generator = mocker.getInstance(CMSSignedDataGenerator.class);
+
+        doAnswer(new Answer() {
+            public Object answer(InvocationOnMock invocation) throws IOException {
+                Object[] args = invocation.getArguments();
+                OutputStream out = (OutputStream) args[0];
+                out.write(DUMPED_BLOCK);
+                return null;
+            }
+        }).when(dumper).dump(any(OutputStream.class), or(eq(MACRO_BLOCK), eq(MARKER_BLOCK)));
+        when(dumper.dump(or(eq(MACRO_BLOCK), eq(MARKER_BLOCK)))).thenReturn(DUMPED_BLOCK);
+
+        when(generator.generate(DUMPED_BLOCK, CMS_PARAMS)).thenReturn(BLOCK_SIGNATURE);
+
+=====================================================================
+Found a 19 line (105 tokens) duplication in the following files: 
+Starting at line 124 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+Starting at line 268 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+
+    void insertImage(TestUtils setup, TestReference testReference) throws Exception
+    {
+        // Run the tests as a normal user. We make the user advanced only to enable the Edit drop down menu.
+        loginStandardUser(setup);
+        String attachmentName = "image.gif";
+        AttachmentReference attachmentReference = new AttachmentReference(attachmentName, testReference);
+        ViewPage newPage = uploadAttachment(setup, testReference, attachmentName);
+
+        // Move to the WYSIWYG edition page.
+        WYSIWYGEditPage wysiwygEditPage = newPage.editWYSIWYG();
+        CKEditor editor = new CKEditor("content").waitToLoad();
+
+        // Insert a first image.
+        ImageDialogSelectModal imageDialogSelectModal = editor.getToolBar().insertImage();
+        imageDialogSelectModal.switchToTreeTab().selectAttachment(attachmentReference);
+        ImageDialogEditModal imageDialogEditModal = imageDialogSelectModal.clickSelect();
+        imageDialogEditModal.clickInsert();
+        // Move the focus out of the newly inserted image widget.
+        editor.getRichTextArea().sendKeys(Keys.RIGHT);
+
+=====================================================================
+Found a 15 line (105 tokens) duplication in the following files: 
+Starting at line 524 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+Starting at line 641 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+
+            assertEquals(currentMajor + ".1", historyPane.getCurrentVersion());
+
+            // Check that the page remained with rights unchanged
+            setup.gotoPage(xwikiPreferences, "edit", "editor=object");
+            objectEditPage = new ObjectEditPage();
+            rightObjects = objectEditPage.getObjectsOfClass("XWiki.XWikiGlobalRights", false);
+            rightObject = rightObjects.get(rightObjects.size() - 1);
+            rightObject.displayObject();
+            assertEquals(deleteVersionTestUser,
+                rightObject.getFieldValue(rightObject.byPropertyName("users")));
+            assertEquals("programming", rightObject.getFieldValue(rightObject.byPropertyName("levels")));
+            assertEquals("0", rightObject.getFieldValue(rightObject.byPropertyName("allow")));
+            // We don't use the Cancel button to leave the edit mode because the XWiki preferences sheet redirects to
+            // "admin" mode which locks back the page. Instead, we go to a page that doesn't add the edit lock back.
+            setup.gotoPage(xwikiPreferences.getLastSpaceReference());
+
+=====================================================================
+Found a 8 line (105 tokens) duplication in the following files: 
+Starting at line 317 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/ModelBridgeTest.java
+Starting at line 372 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/ModelBridgeTest.java
+
+        entry.put("field", 55);
+        DocumentReference documentReference = new DocumentReference("xwiki", "MyTest", "MyDoc");
+        DocumentReference classReference = new DocumentReference("xwiki", "MyTest", "MyClass");
+
+        when(this.xwiki.getDocument(documentReference, this.xcontext)).thenReturn(this.document);
+        when(this.document.getXObject(classReference, 0)).thenReturn(this.baseObject);
+        when(this.baseObject.getXClass(this.xcontext)).thenReturn(this.baseClass);
+        when(this.baseObject.getPropertyNames()).thenReturn(new String[] { "field" });
+
+=====================================================================
+Found a 11 line (105 tokens) duplication in the following files: 
+Starting at line 62 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/UserMentionsFormatterTest.java
+Starting at line 80 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/UserMentionsFormatterTest.java
+
+    void formatMentionNoFirstNameNoLastName()
+    {
+        UserReference userReference = mock(UserReference.class);
+        UserProperties userProperties = mock(UserProperties.class);
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "User");
+
+        when(this.userReferenceResolver.resolve("xwiki:XWiki.User")).thenReturn(userReference);
+        when(this.userPropertiesResolver.resolve(userReference)).thenReturn(userProperties);
+        when(this.documentReferenceResolver.resolve("xwiki:XWiki.User")).thenReturn(documentReference);
+        when(userProperties.getFirstName()).thenReturn(null);
+        when(userProperties.getLastName()).thenReturn(null);
+
+=====================================================================
+Found a 11 line (105 tokens) duplication in the following files: 
+Starting at line 98 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/UserMentionsFormatterTest.java
+Starting at line 152 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/UserMentionsFormatterTest.java
+
+    void formatMentionNoLastName()
+    {
+        UserReference userReference = mock(UserReference.class);
+        UserProperties userProperties = mock(UserProperties.class);
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "User");
+
+        when(this.userReferenceResolver.resolve("xwiki:XWiki.User")).thenReturn(userReference);
+        when(this.userPropertiesResolver.resolve(userReference)).thenReturn(userProperties);
+        when(this.documentReferenceResolver.resolve("xwiki:XWiki.User")).thenReturn(documentReference);
+        when(userProperties.getFirstName()).thenReturn("First Name");
+        when(userProperties.getLastName()).thenReturn(null);
+
+=====================================================================
+Found a 11 line (105 tokens) duplication in the following files: 
+Starting at line 126 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+Starting at line 208 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+Starting at line 288 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+Starting at line 368 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+
+    void getPageWatchStatusSpace() throws Exception
+    {
+        DocumentReference userDocReference = new DocumentReference("xwiki", "XWiki", "User");
+        when(this.context.getUserReference()).thenReturn(userDocReference);
+        UserReference userReference = mock(UserReference.class);
+        when(this.userReferenceResolver.resolve(userDocReference)).thenReturn(userReference);
+        String wikiName = "fooWiki";
+        SpaceReference spaceReference = new SpaceReference(wikiName, List.of("Foo", "Bar", "Space"));
+        WatchedLocationReference watchedLocationReference = mock(WatchedLocationReference.class);
+        when(this.watchedEntityFactory.createWatchedLocationReference(spaceReference))
+            .thenReturn(watchedLocationReference);
+
+=====================================================================
+Found a 13 line (105 tokens) duplication in the following files: 
+Starting at line 314 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiAttachmentTest.java
+Starting at line 362 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiAttachmentTest.java
+
+        when(compactWikiEntityReferenceSerializer.serialize(userReference, attachment.getReference()))
+            .thenReturn("stringUserReference");
+        assertEquals("stringUserReference", attachment.getAuthor());
+
+        // getAuthorReference() based on getAuthor()
+        attachment.setAuthor("author");
+        assertEquals("author", attachment.getAuthor());
+        userReference = new DocumentReference("wiki", "XWiki", "author");
+        EntityReference relativeUserReference = userReference.removeParent(userReference.getWikiReference());
+        when(xclassEntityReferenceResolver.resolve("author", EntityType.DOCUMENT)).thenReturn(relativeUserReference);
+        when(explicitDocumentReferenceResolver.resolve(relativeUserReference, attachment.getReference()))
+            .thenReturn(userReference);
+        assertEquals(userReference, attachment.getAuthorReference());
+
+=====================================================================
+Found a 15 line (105 tokens) duplication in the following files: 
+Starting at line 145 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/UndeleteActionTest.java
+Starting at line 159 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/UndeleteActionTest.java
+
+    void restoreSingleDocument() throws Exception
+    {
+        when(this.csrfToken.isTokenValid(null)).thenReturn(true);
+
+        when(this.recycleBinStore.hasAccess(any(), any(), any()))
+            .thenReturn(true);
+        assertFalse(this.undeleteAction.action(this.oldcore.getXWikiContext()));
+
+        verify(this.requestFactory).createRestoreRequest(Arrays.asList(ID));
+        verify(jobExecutor).execute(RefactoringJobs.RESTORE, jobRequest);
+        verify(job).join();
+    }
+
+    @Test
+    void restoreSingleDocumentWhenDeleter() throws Exception
+
+=====================================================================
+Found a 16 line (105 tokens) duplication in the following files: 
+Starting at line 68 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/util/XWikiIconProviderTest.java
+Starting at line 102 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/util/XWikiIconProviderTest.java
+
+    void get() throws Exception
+    {
+        // Setting up the mocks
+        // Mock behaviour for the iconsetManager
+        IconSet currentIconSet = new IconSet("fontawesome");
+        IconSet defaultIconSet = new IconSet("silk");
+        currentIconSet.addIcon("test", new Icon("hello"));
+        when(iconSetManager.getCurrentIconSet()).thenReturn(currentIconSet);
+        when(iconSetManager.getDefaultIconSet()).thenReturn(defaultIconSet);
+
+        // Mock behaviour for the iconRenderer
+        String testIconFA = "<span class=\"fa fa-test\"aria-hidden=\"true\"></span>";
+        String testIconSilk = "<img src=\"$xwiki.getSkinFile(\"icons/silk/test.png\")\" alt=\"\" " +
+            "data-xwiki-lightbox=\"false\" />";
+        when(this.iconRenderer.renderHTML("test", currentIconSet)).thenReturn(testIconFA);
+        when(this.iconRenderer.renderHTML("test", defaultIconSet)).thenReturn(testIconSilk);
+
+=====================================================================
+Found a 15 line (105 tokens) duplication in the following files: 
+Starting at line 199 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+Starting at line 246 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+
+            this.xwiki.getDocument(new DocumentReference("xwiki", "Space", "/}}{{/html}}{{noscript/}}"), this.context);
+        xwikiDocument.getXClass().addTextField("testField", "Test Field", 10);
+        BaseObject baseObject = xwikiDocument.newXObject(CLASS_SHEET_BINDING_DOCUMENT_REFERENCE, this.context);
+        baseObject.set("sheet", alreadyExistsPageName, this.context);
+        this.xwiki.saveDocument(xwikiDocument, this.context);
+        XWikiDocument doc = loadPage(XWIKI_CLASS_SHEET);
+
+        // Set up the current doc in the context so that $doc is bound in scripts
+        this.context.setDoc(xwikiDocument);
+
+        Document document = render(doc);
+
+        Elements h1s = document.select("h1");
+        assertEquals("platform.xclass.defaultClassSheet.properties.heading", h1s.get(0).text());
+        assertEquals("platform.xclass.defaultClassSheet.pages.heading", h1s.get(1).text());
+
+=====================================================================
+Found a 16 line (105 tokens) duplication in the following files: 
+Starting at line 375 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+Starting at line 415 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+
+        this.xwiki.saveDocument(pageTemplate, this.context);
+
+        XWikiDocument doc = loadPage(XWIKI_CLASS_SHEET);
+
+        this.request.put("docName", "DOC_NAME");
+
+        // Set up the current doc in the context so that $doc is bound in scripts
+        this.context.setDoc(xwikiDocument);
+
+        Document document = render(doc);
+
+        Elements infomessages = document.select(".infomessage");
+        assertEquals("platform.xclass.defaultClassSheet.sheets.description [, ]", infomessages.get(0).text());
+        assertEquals("platform.xclass.defaultClassSheet.template.description [, ]", infomessages.get(1).text());
+        assertEquals("platform.xclass.defaultClassSheet.templateProvider.description []", infomessages.get(2).text());
+        assertNotNull(infomessages.get(2).selectFirst("em"));
+
+=====================================================================
+Found a 12 line (104 tokens) duplication in the following files: 
+Starting at line 143 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/ConfigurableClassIT.java
+Starting at line 342 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/ConfigurableClassIT.java
+
+            "//div/div/p/span/input[@type='submit'][@value='Save']"));
+
+        FormContainerElement formContainerElement = asp.getFormContainerElement();
+
+        // Form and fields
+        assertEquals(String.format("%ssave/%s", setup.getBaseBinURL(), fullName.replace('.', '/')),
+            formContainerElement.getFormAction());
+        assertEquals(setup.getDriver().getCurrentUrl(),
+            formContainerElement.getFieldValue(By.name("xredirect")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_String")));
+        assertTrue(formContainerElement.hasField(By.name(fullName + "_0_Boolean")));
+        assertTrue(formContainerElement.hasField(By.id(fullName + "_redirect")));
+
+=====================================================================
+Found a 17 line (104 tokens) duplication in the following files: 
+Starting at line 225 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/test/java/org/xwiki/component/internal/ContextComponentManagerTest.java
+Starting at line 380 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/test/java/org/xwiki/component/internal/ContextComponentManagerTest.java
+
+    public void testDeleteDocument() throws Exception
+    {
+        getMockery().checking(new Expectations()
+        {
+            {
+                allowing(mockWikiDescriptorManager).getCurrentWikiId();
+                will(returnValue("wiki"));
+                allowing(mockCurrentSpaceReferenceProvider).get();
+                will(returnValue(new SpaceReference("space", new WikiReference("wiki"))));
+                allowing(mockCurrentDocumentReferenceProvider).get();
+                will(returnValue(new DocumentReference("wiki", "space", "document")));
+                allowing(mockDocumentAccessBridge).getCurrentUserReference();
+                will(returnValue(new DocumentReference("wiki", "XWiki", "user")));
+            }
+        });
+
+        ComponentManager documentCM = getComponentManager().getInstance(ComponentManager.class, "document");
+
+=====================================================================
+Found a 11 line (104 tokens) duplication in the following files: 
+Starting at line 281 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+Starting at line 331 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509CertificateWikiStoreTest.java
+
+    public void testUpdatingCertificateWithKeyIdToDocument() throws Exception
+    {
+        XWikiDocument storeDoc = mock(XWikiDocument.class);
+        when(xwiki.getDocument(new DocumentReference(WIKI, SPACE, DOCUMENT), xcontext)).thenReturn(storeDoc);
+
+        BaseObject certObj = mock(BaseObject.class);
+        when(storeDoc.getXObject(X509CertificateWikiStore.CERTIFICATECLASS, 123)).thenReturn(certObj);
+
+        when(query.<Object[]>execute()).thenReturn(Collections.singletonList(new Object[]{"space.document", 123}));
+
+        store.store(DOC_STORE_REF, getMockedCertificate(true));
+
+=====================================================================
+Found a 17 line (104 tokens) duplication in the following files: 
+Starting at line 718 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-tests/src/test/java/org/xwiki/test/ui/extension/ExtensionIT.java
+Starting at line 892 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-tests/src/test/java/org/xwiki/test/ui/extension/ExtensionIT.java
+
+    public void testUpgrade() throws Exception
+    {
+        // Setup the extension.
+        String extensionId = "alice-xar-extension";
+        String oldVersion = "1.3";
+        String newVersion = "2.1.4";
+        TestExtension oldExtension =
+            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, oldVersion), "xar");
+        getRepositoryTestUtils().addExtension(oldExtension);
+        TestExtension newExtension =
+            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, newVersion), "xar");
+        getRepositoryTestUtils().attachFile(newExtension);
+        getRepositoryTestUtils().addVersionObject(newExtension, newVersion,
+            "attach:" + newExtension.getFile().getName());
+
+        // Make sure the old version is installed.
+        getExtensionTestUtils().install(new ExtensionId(extensionId, oldVersion));
+
+=====================================================================
+Found a 10 line (104 tokens) duplication in the following files: 
+Starting at line 96 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamTest.java
+Starting at line 122 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamTest.java
+Starting at line 167 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamTest.java
+Starting at line 212 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamTest.java
+
+    void postPublicMessage() throws Exception
+    {
+        DefaultEvent t = new DefaultEvent();
+        t.setId("eid");
+        when(this.factory.createEvent()).thenReturn(t);
+        when(this.context.getCurrentEntityReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.bridge.getCurrentUserReference()).thenReturn(USER_DOCUMENT_REFERENCE);
+        when(this.serializer.serialize(USER_DOCUMENT_REFERENCE)).thenReturn(USER_REFERENCE);
+        CompletableFuture completableFuture = mock(CompletableFuture.class);
+        when(this.eventStore.saveEvent(t)).thenReturn(completableFuture);
+
+=====================================================================
+Found a 8 line (104 tokens) duplication in the following files: 
+Starting at line 191 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+Starting at line 247 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+
+        List<MacroBlock> newMentions = List.of(new MacroBlock("mention", new HashMap<>(), false));
+        when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
+
+        Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
+        oldCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor0", "anchor1"));
+        when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
+        Map<MentionedActorReference, List<String>> newCounts = new HashMap<>();
+        newCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor0", "anchor1"));
+
+=====================================================================
+Found a 14 line (104 tokens) duplication in the following files: 
+Starting at line 49 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java
+
+            @QueryParam("untilDateIncluded") @DefaultValue("true") boolean untilDateIncluded,
+            @QueryParam("blackList") String blackList,
+            @QueryParam("pages") String pages,
+            @QueryParam("spaces") String spaces,
+            @QueryParam("wikis") String wikis,
+            @QueryParam("users") String users,
+            @QueryParam("count") String count,
+            @QueryParam("displayOwnEvents") String displayOwnEvents,
+            @QueryParam("displayMinorEvents") String displayMinorEvents,
+            @QueryParam("displaySystemEvents") String displaySystemEvents,
+            @QueryParam("displayReadEvents") String displayReadEvents,
+            @QueryParam("displayReadStatus") String displayReadStatus,
+            @QueryParam("tags") String tags,
+            @QueryParam("currentWiki") String currentWiki,
+
+=====================================================================
+Found a 13 line (104 tokens) duplication in the following files: 
+Starting at line 116 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+Starting at line 468 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/EventQueryGeneratorTest.java
+
+        parameters.filterPreferences = Arrays.asList(this.fakeFilterPreference);
+
+        SimpleEventQuery query = this.generator.generateQuery(parameters);
+
+        Iterator<QueryCondition> conditions = query.getConditions().iterator();
+
+        assertEquals(new CompareQueryCondition(Event.FIELD_DATE, this.startDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+        assertEquals(new CompareQueryCondition(Event.FIELD_TYPE, "create", CompareType.EQUALS, false),
+            conditions.next());
+        assertEquals(
+            new CompareQueryCondition(Event.FIELD_DATE, this.pref1StartDate, CompareType.GREATER_OR_EQUALS, false),
+            conditions.next());
+
+=====================================================================
+Found a 13 line (104 tokens) duplication in the following files: 
+Starting at line 395 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 453 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 799 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void existingDocumentFromUI() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Submit from the UI spaceReference=X&name=Y
+        when(mockRequest.getParameter("spaceReference")).thenReturn("X");
+        when(mockRequest.getParameter("name")).thenReturn("Y");
+
+=====================================================================
+Found a 13 line (104 tokens) duplication in the following files: 
+Starting at line 424 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 483 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void existingDocumentFromUICheckEscaping() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Submit from the UI spaceReference=X.Y&name=Z
+        when(mockRequest.getParameter("spaceReference")).thenReturn("X.Y");
+        when(mockRequest.getParameter("name")).thenReturn("Z");
+
+=====================================================================
+Found a 13 line (104 tokens) duplication in the following files: 
+Starting at line 646 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+Starting at line 734 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+
+    void existingDocumentFromUIDeprecated() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
+        context.setDoc(document);
+
+        // Submit from the UI space=X&page=Y
+        when(mockRequest.getParameter("space")).thenReturn("X");
+        when(mockRequest.getParameter("page")).thenReturn("Y");
+
+=====================================================================
+Found a 16 line (104 tokens) duplication in the following files: 
+Starting at line 815 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+Starting at line 894 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+
+    void recomputeAverageRating() throws Exception
+    {
+        when(this.configuration.isAverageStored()).thenReturn(true);
+        when(this.solr.getClient(RatingSolrCoreInitializer.DEFAULT_RATINGS_SOLR_CORE)).thenReturn(this.solrClient);
+
+        EntityReference inputReference = mock(EntityReference.class);
+        when(inputReference.toString()).thenReturn("document:Input.Reference");
+        String managerId = "myManager";
+
+        this.manager.setIdentifier(managerId);
+
+        String filterQuery = String.format("filter(%s:%s) AND filter(%s:%s)",
+            RatingQueryField.ENTITY_REFERENCE.getFieldName(), "document\\:Input.Reference",
+            RatingQueryField.MANAGER_ID.getFieldName(), managerId);
+
+        SolrQuery expectedQuery1 = new SolrQuery()
+
+=====================================================================
+Found a 15 line (104 tokens) duplication in the following files: 
+Starting at line 473 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+Starting at line 549 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+Starting at line 574 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+
+        when(this.compactEntityReferenceSerializer.serialize(hierarchicalParent, documentReference))
+            .thenReturn(serializedParent);
+        when(this.relativeStringEntityReferenceResolver.resolve(serializedParent, EntityType.DOCUMENT))
+            .thenReturn(hierarchicalParent.getLocalDocumentReference());
+
+        this.modelBridge.update(documentReference, Collections.emptyMap());
+
+        verify(clonedDocument).setParentReference(hierarchicalParent.getLocalDocumentReference());
+        verify(this.xcontext.getWiki()).saveDocument(clonedDocument, "Update document after refactoring.", true,
+            xcontext);
+        assertLog(Level.INFO, "Document [{}] has been updated.", documentReference);
+    }
+
+    @Test
+    void dontUpdateParentDifferentWikiSameSpace() throws Exception
+
+=====================================================================
+Found a 15 line (104 tokens) duplication in the following files: 
+Starting at line 77 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/test/java/org/xwiki/wiki/user/internal/WikiUserFromXEMMigrationTest.java
+Starting at line 69 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/test/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspaceMigrationTest.java
+
+        wikiUserConfigurationHelper = mocker.getInstance(WikiUserConfigurationHelper.class);
+        execution = mock(Execution.class);
+        mocker.registerComponent(Execution.class, execution);
+        xcontext = mock(XWikiContext.class);
+        xwiki = mock(XWiki.class);
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(execution.getContext()).thenReturn(executionContext);
+        when(executionContext.getProperty("xwikicontext")).thenReturn(xcontext);
+        when(xcontext.getWiki()).thenReturn(xwiki);
+        when(wikiDescriptorManager.getMainWikiId()).thenReturn("mainWiki");
+    }
+
+    @Test
+    public void upgradeRegularSubWiki() throws Exception
+
+=====================================================================
+Found a 13 line (103 tokens) duplication in the following files: 
+Starting at line 144 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroTest.java
+Starting at line 155 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
+
+        this.rendererFactory = this.componentManager.getInstance(PrintRendererFactory.class, "event/1.0");
+
+        // Put a fake XWiki context on the execution context.
+        Execution execution = this.componentManager.getInstance(Execution.class);
+        ExecutionContextManager ecm = this.componentManager.getInstance(ExecutionContextManager.class);
+        ExecutionContext ec = new ExecutionContext();
+        ecm.initialize(ec);
+        execution.getContext().setProperty("xwikicontext", new HashMap<>());
+
+        when(this.contextualAuthorizationManager.hasAccess(Right.SCRIPT)).thenReturn(true);
+        when(this.contextualAuthorizationManager.hasAccess(Right.PROGRAM)).thenReturn(true);
+        // Register a WikiModel mock so that we're in wiki mode (otherwise links will be considered as URLs for ex).
+        this.componentManager.registerMockComponent(WikiModel.class);
+
+=====================================================================
+Found a 14 line (103 tokens) duplication in the following files: 
+Starting at line 317 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandlerTest.java
+Starting at line 495 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandlerTest.java
+
+        assertFalse("Document is minor edit", page.isMinorEdit());
+
+        BaseClass baseClass = page.getXClass();
+        assertNotNull(baseClass.getField("property"));
+        assertEquals("property", baseClass.getField("property").getName());
+        assertSame(NumberClass.class, baseClass.getField("property").getClass());
+
+        // space.pagewithattachment
+
+        XWikiDocument pagewithattachment = this.oldcore.getSpyXWiki()
+            .getDocument(new DocumentReference("wiki", "space", "pagewithattachment"), getXWikiContext());
+        assertFalse(pagewithattachment.isNew());
+        assertEquals("Wrong version", "1.1", pagewithattachment.getVersion());
+        assertEquals("Wrong creator", this.contextUser, pagewithattachment.getCreatorReference());
+
+=====================================================================
+Found a 14 line (103 tokens) duplication in the following files: 
+Starting at line 144 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-default/src/test/java/org/xwiki/icon/internal/DefaultIconThemesResourceTest.java
+Starting at line 187 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-default/src/test/java/org/xwiki/icon/internal/DefaultIconThemesResourceTest.java
+
+    void getIconsByTheme() throws Exception
+    {
+        Map<String, Object> iconAMetaData = new HashMap<>();
+        iconAMetaData.put("iconSetName", "testTheme");
+        iconAMetaData.put("iconSetType", "TYPETEST");
+        iconAMetaData.put("url", "");
+        iconAMetaData.put("cssClass", "testclass");
+        Map<String, Object> iconBMetaData = new HashMap<>();
+        iconBMetaData.put("iconSetName", "testTheme");
+        iconBMetaData.put("iconSetType", "TYPETEST2");
+        iconBMetaData.put("url", "http://test/url");
+        iconBMetaData.put("cssClass", "");
+
+        when(this.iconSetManager.getIconSet("testTheme")).thenReturn(new IconSet("testTheme"));
+
+=====================================================================
+Found a 12 line (103 tokens) duplication in the following files: 
+Starting at line 164 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+Starting at line 189 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+
+    public void testVerifyMultipleObjectsXWikiClassNotChanged() throws XWikiException
+    {
+        XWikiDocument newDoc = this.classDoc.clone();
+        XWikiDocument oldDoc = this.classDoc.clone();
+
+        BaseObject otherOldObject = oldDoc.newObject(this.otherClassName, this.context);
+        BaseObject oldObj = oldDoc.newObject(this.testClassName, this.context);
+        BaseObject otherNewObject = newDoc.newObject(this.otherClassName, this.context);
+        BaseObject newObj = newDoc.newObject(this.testClassName, this.context);
+
+        otherOldObject.setStringValue(this.testPropertyName, "value1");
+        oldObj.setStringValue(this.testPropertyName, "value");
+
+=====================================================================
+Found a 7 line (103 tokens) duplication in the following files: 
+Starting at line 213 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 513 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+    void orderByLocation() throws Exception
+    {
+        when(this.queryService.hql(anyString())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+
+=====================================================================
+Found a 9 line (103 tokens) duplication in the following files: 
+Starting at line 136 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/template/DefaultMailTemplateManagerTest.java
+Starting at line 171 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/template/DefaultMailTemplateManagerTest.java
+
+        when(documentBridge.getObjectNumber(any(), any(), eq("language"), eq("fr"))).thenReturn(1);
+        when(documentBridge.getProperty(any(DocumentReference.class), any(), eq(1), eq("html")))
+            .thenReturn("Salut <b>${name}</b> <br />${email}");
+
+        VelocityEngine velocityEngine = mock(VelocityEngine.class);
+        VelocityManager velocityManager = this.componentManager.getInstance(VelocityManager.class);
+        when(velocityManager.getVelocityEngine()).thenReturn(velocityEngine);
+        when(this.velocityEvaluator.evaluateVelocity(eq("Salut <b>${name}</b> <br />${email}"), any(),
+            any())).thenReturn("Salut <b>John Doe</b> <br />john@doe.com");
+
+=====================================================================
+Found a 19 line (103 tokens) duplication in the following files: 
+Starting at line 219 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+Starting at line 250 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, newReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, oldReference)).thenReturn(true);
+
+        MoveRequest request = createRequest(oldReference, newReference.getParent());
+        request.setCheckRights(true);
+        request.setCheckAuthorRights(true);
+        request.setUserReference(userReference);
+        request.setAuthorReference(authorReference);
+        run(request);
+
+        assertEquals("You don't have sufficient permissions over the destination document [wiki:Two.Page].",
+            getLogCapture().getMessage(0));
+        assertEquals(Level.ERROR, getLogCapture().getLogEvent(0).getLevel());
+
+        verifyNoMove();
+    }
+
+    @Test
+    void moveDocumentToRestrictedDestinationAuthor() throws Throwable
+
+=====================================================================
+Found a 13 line (103 tokens) duplication in the following files: 
+Starting at line 62 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertiesResourceImpl.java
+Starting at line 61 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassResourceImpl.java
+
+    public Properties getClassProperties(String wikiName, String className) throws XWikiRestException
+    {
+        String database = Utils.getXWikiContext(componentManager).getWikiId();
+
+        try {
+            Utils.getXWikiContext(componentManager).setWikiId(wikiName);
+
+            DocumentReference classReference = this.resolver.resolve(className, new WikiReference(wikiName));
+            this.authorization.checkAccess(Right.VIEW, classReference);
+            com.xpn.xwiki.api.Class xwikiClass = Utils.getXWikiApi(componentManager).getClass(classReference);
+            if (xwikiClass == null) {
+                throw new WebApplicationException(Status.NOT_FOUND);
+            }
+
+=====================================================================
+Found a 17 line (103 tokens) duplication in the following files: 
+Starting at line 161 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/DocumentSolrMetadataExtractorTest.java
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/ObjectPropertySolrMetadataExtractorTest.java
+
+    void setUp() throws Exception
+    {
+        // XWikiContext Provider
+        when(this.contextProvider.get()).thenReturn(this.xcontext);
+
+        // XWikiContext trough Execution
+        ExecutionContext executionContext = new ExecutionContext();
+        executionContext.setProperty(XWikiContext.EXECUTIONCONTEXT_KEY, this.xcontext);
+        when(this.execution.getContext()).thenReturn(executionContext);
+
+        // XWiki
+        XWiki wiki = mock(XWiki.class);
+        when(this.xcontext.getWiki()).thenReturn(wiki);
+
+        // XWikiDocument
+        when(wiki.getDocument(this.documentReference, this.xcontext)).thenReturn(this.document);
+        when(this.document.getDocumentReference()).thenReturn(this.documentReference);
+
+=====================================================================
+Found a 20 line (103 tokens) duplication in the following files: 
+Starting at line 643 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/DefaultWikiUserManager.java
+Starting at line 670 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/DefaultWikiUserManager.java
+
+        invitation.setStatus(MemberCandidacy.Status.ACCEPTED);
+        invitation.setDateOfClosure(new Date());
+
+        // Get the group document
+        XWikiDocument groupDoc = getMembersGroupDocument(invitation.getWikiId());
+
+        // Avoid modifying the cached document
+        groupDoc = groupDoc.clone();
+
+        // Get the candidacy object
+        BaseObject object = groupDoc.getXObject(WikiCandidateMemberClassInitializer.REFERENCE, invitation.getId());
+
+        // Set the new values
+        object.setLargeStringValue(WikiCandidateMemberClassInitializer.FIELD_USER_COMMENT, invitation.getUserComment());
+        object.setDateValue(WikiCandidateMemberClassInitializer.FIELD_DATE_OF_CLOSURE, invitation.getDateOfClosure());
+        object.setStringValue(WikiCandidateMemberClassInitializer.FIELD_STATUS,
+                invitation.getStatus().name().toLowerCase());
+
+        // Save the document
+        saveGroupDocument(groupDoc, String.format("User [%s] has accepted to join the wiki. ", invitation.getUserId()));
+
+=====================================================================
+Found a 22 line (102 tokens) duplication in the following files: 
+Starting at line 319 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
+Starting at line 517 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBTreeListClass.java
+
+                        whereStatements.add("obj.id=valueprop.id.id and valueprop.id.name='" + valueField + "'");
+                    }
+                }
+                // Let's create the complete query
+                select.append(" from ");
+                select.append(StringUtils.join(fromStatements.iterator(), ", "));
+                if (whereStatements.size() > 0) {
+                    select.append(" where ");
+                    select.append(StringUtils.join(whereStatements.iterator(), " and "));
+                }
+                sql = select.toString();
+            } else {
+                // TODO: query plugin impl.
+                // We need to generate the right query for the query plugin
+            }
+        }
+        // Parse the query, so that it can contain velocity scripts, for example to use the
+        // current document name, or the current username.
+        try {
+            sql = context.getWiki().parseContent(sql, context);
+        } catch (Exception e) {
+            LOGGER.error("Failed to parse SQL script [{}]. Continuing with non-rendered script.", sql, e);
+
+=====================================================================
+Found a 16 line (102 tokens) duplication in the following files: 
+Starting at line 328 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/XWikiServletURLFactoryTest.java
+Starting at line 346 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/XWikiServletURLFactoryTest.java
+
+        this.httpHeaders.put("x-forwarded-host", "www.xwiki.org");
+        // Reinitialize the URL factory to take into account the new HTTP headers.
+        this.urlFactory.init(this.oldcore.getXWikiContext());
+
+        this.oldcore.getMockXWikiCfg().setProperty("xwiki.virtual.usepath", "0");
+
+        URL url = this.urlFactory.createURL("Space", "Page", "view", "param1=1", "anchor", "wiki1",
+            this.oldcore.getXWikiContext());
+        assertEquals("http://wiki1server/xwiki/bin/view/Space/Page?param1=1#anchor", url.toString());
+        // The URL remains absolute in this case.
+        assertEquals("http://wiki1server/xwiki/bin/view/Space/Page?param1=1#anchor",
+            this.urlFactory.getURL(url, this.oldcore.getXWikiContext()));
+    }
+
+    @Test
+    void createURLOnSubWikiModeInDomainModeInReverseProxyMode()
+
+=====================================================================
+Found a 11 line (102 tokens) duplication in the following files: 
+Starting at line 224 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+Starting at line 251 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+
+        List<PasswordProperty> passwordPropertyListSession1 = new ArrayList<>();
+        for (int i = beginLoop; i < endLoop; i++) {
+            StringProperty stringProperty = mock(StringProperty.class);
+            when(stringProperty.getName()).thenReturn("password");
+            when(stringProperty.getId()).thenReturn(Long.valueOf(i));
+            when(stringProperty.getValue()).thenReturn("mypassword_" + i);
+
+            PasswordProperty passwordProperty = new PasswordProperty();
+            passwordProperty.setName("password");
+            passwordProperty.setValue("mypassword_" + i);
+            passwordProperty.setId(i);
+
+=====================================================================
+Found a 11 line (102 tokens) duplication in the following files: 
+Starting at line 280 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+Starting at line 315 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+Starting at line 342 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+Starting at line 369 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+Starting at line 403 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+Starting at line 430 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+Starting at line 458 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/migration/R180100000XWIKI23827DataMigrationTest.java
+
+        List<PasswordProperty> passwordPropertyListSession3 = new ArrayList<>();
+        for (int i = beginLoop; i < endLoop; i++) {
+            StringProperty stringProperty = mock(StringProperty.class);
+            when(stringProperty.getName()).thenReturn("reset");
+            when(stringProperty.getId()).thenReturn(Long.valueOf(i));
+            when(stringProperty.getValue()).thenReturn("mypassword_" + i);
+
+            PasswordProperty passwordProperty = new PasswordProperty();
+            passwordProperty.setName("reset");
+            passwordProperty.setValue("mypassword_" + i);
+            passwordProperty.setId(i);
+
+=====================================================================
+Found a 8 line (102 tokens) duplication in the following files: 
+Starting at line 239 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+Starting at line 381 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+
+        documentResult.put(RatingQueryField.MANAGER_ID.getFieldName(), "otherId");
+        documentResult.put(RatingQueryField.CREATED_DATE.getFieldName(), new Date(1));
+        documentResult.put(RatingQueryField.UPDATED_DATE.getFieldName(), new Date(1111));
+        documentResult.put(RatingQueryField.VOTE.getFieldName(), 8);
+        documentResult.put(RatingQueryField.SCALE.getFieldName(), 10);
+        documentResult.put(RatingQueryField.ENTITY_REFERENCE.getFieldName(), "attachment:Foo");
+        EntityReference reference1 = mock(EntityReference.class);
+        documentResult.put(RatingQueryField.USER_REFERENCE.getFieldName(), "user:barfoo");
+
+=====================================================================
+Found a 15 line (102 tokens) duplication in the following files: 
+Starting at line 499 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+Starting at line 525 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+
+        when(this.compactEntityReferenceSerializer.serialize(hierarchicalParent, documentReference))
+            .thenReturn(serializedParent);
+        when(this.relativeStringEntityReferenceResolver.resolve(serializedParent, EntityType.DOCUMENT))
+            .thenReturn(hierarchicalParent.getLocalDocumentReference());
+
+        this.modelBridge.update(documentReference, Collections.emptyMap());
+
+        // no need to update the parent: different wiki but same relative reference
+        verify(document, never()).setParentReference(hierarchicalParent.getLocalDocumentReference());
+        verify(this.xcontext.getWiki(), never()).saveDocument(document, "Update document after refactoring.", true,
+            xcontext);
+    }
+
+    @Test
+    void dontUpdateParentInCaseOfPageRename() throws Exception
+
+=====================================================================
+Found a 14 line (102 tokens) duplication in the following files: 
+Starting at line 211 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManagerTest.java
+Starting at line 246 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManagerTest.java
+
+    void uploadAttachmentInvalid() throws Exception
+    {
+        setupSession();
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "Document");
+        SpaceReference spaceReference = documentReference.getLastSpaceReference();
+
+        XWiki xwiki = mock(XWiki.class);
+        Part part = mock(Part.class);
+
+        when(this.context.getWiki()).thenReturn(xwiki);
+        when(xwiki.getSpacePreference(UPLOAD_MAXSIZE_PARAMETER, spaceReference, this.context))
+            .thenReturn("42");
+
+        when(part.getInputStream()).thenReturn(new ByteArrayInputStream("foo".getBytes(UTF_8)));
+
+=====================================================================
+Found a 11 line (102 tokens) duplication in the following files: 
+Starting at line 90 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/descriptor/migrator/WikiDescriptorMigratorTest.java
+Starting at line 140 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/descriptor/migrator/WikiDescriptorMigratorTest.java
+
+    public void hibernateMigrate() throws Exception
+    {
+        List<String> documentList = new ArrayList<>();
+        documentList.add("XWiki.XWikiServerSubwiki1");
+
+        Query query = mock(Query.class);
+        when(queryManager.createQuery(any(), eq(Query.HQL))).thenReturn(query);
+        when(query.<String>execute()).thenReturn(documentList);
+
+        DocumentReference documentReference = new DocumentReference("mainWiki", "XWiki", "XWikiServerSubwiki1");
+        when(documentReferenceResolver.resolve(documentList.get(0))).thenReturn(documentReference);
+
+=====================================================================
+Found a 19 line (101 tokens) duplication in the following files: 
+Starting at line 163 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+Starting at line 780 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+
+    void insertImageWithStyle(TestUtils setup, TestReference testReference) throws Exception
+    {
+        createBorderedStyle(setup);
+
+        // Then test the image styles on the image dialog as a standard user.
+        loginStandardUser(setup);
+        String attachmentName = "image.gif";
+        AttachmentReference attachmentReference = new AttachmentReference(attachmentName, testReference);
+        ViewPage newPage = uploadAttachment(setup, testReference, attachmentName);
+
+        // Move to the WYSIWYG edition page.
+        WYSIWYGEditPage wysiwygEditPage = newPage.editWYSIWYG();
+        CKEditor editor = new CKEditor("content").waitToLoad();
+
+        // Insert a first image.
+        ImageDialogSelectModal imageDialogSelectModal = editor.getToolBar().insertImage();
+        imageDialogSelectModal.switchToTreeTab().selectAttachment(attachmentReference);
+        ImageDialogEditModal imageDialogEditModal = imageDialogSelectModal.clickSelect();
+        ImageDialogStandardEditForm imageDialogStandardEditForm = imageDialogEditModal.switchToStandardTab();
+
+=====================================================================
+Found a 14 line (101 tokens) duplication in the following files: 
+Starting at line 203 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509KeyWikiStoreTest.java
+Starting at line 249 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/test/java/org/xwiki/crypto/store/wiki/internal/X509KeyWikiStoreTest.java
+
+        store.store(DOC_STORE_REF, keyPair);
+
+        verify(certObj).setStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_KEYID, ENCODED_SUBJECTKEYID);
+        verify(certObj).setStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_ISSUER, ISSUER);
+        verify(certObj).setStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SERIAL, SERIAL.toString());
+        verify(certObj).setStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_SUBJECT, SUBJECT);
+        verify(certObj).setLargeStringValue(X509CertificateWikiStore.CERTIFICATECLASS_PROP_CERTIFICATE, ENCODED_CERTIFICATE);
+        verify(pkObj).setLargeStringValue(X509KeyWikiStore.PRIVATEKEYCLASS_PROP_KEY, ENCODED_PRIVATEKEY);
+
+        verify(xwiki).saveDocument(storeDoc, xcontext);
+    }
+
+    @Test
+    public void storingPrivateKeyToCertificateDocument() throws Exception
+
+=====================================================================
+Found a 17 line (101 tokens) duplication in the following files: 
+Starting at line 418 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test/xwiki-platform-invitation-test-docker/src/test/it/org/xwiki/invitation/test/docker/InvitationIT.java
+Starting at line 485 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test/xwiki-platform-invitation-test-docker/src/test/it/org/xwiki/invitation/test/docker/InvitationIT.java
+
+    void declineInvitation(TestUtils setup) throws Exception
+    {
+        try {
+            startGreenMail();
+            InvitationSenderPage invitationSenderPage = InvitationSenderPage.gotoPage();
+            invitationSenderPage.fillInDefaultValues();
+            invitationSenderPage.send();
+            getGreenMail().waitForIncomingEmail(10000, 1);
+            MimeMessage[] messages = getGreenMail().getReceivedMessages();
+            String htmlMessage = getMessageContent(messages[0]).get("htmlPart");
+            assertEquals(1, invitationSenderPage.getFooter().myPendingInvitations(),
+                "New invitation is not listed as pending in the footer.");
+            // Now switch to guest.
+            setup.forceGuestUser();
+
+            InvitationGuestActionsPage guestPage =
+                InvitationGuestActionsPage.gotoPage(htmlMessage, InvitationGuestActionsPage.Action.DECLINE);
+
+=====================================================================
+Found a 14 line (101 tokens) duplication in the following files: 
+Starting at line 261 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-script/src/test/java/org/xwiki/lesscss/LessCompilerScriptServiceTest.java
+Starting at line 306 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-script/src/test/java/org/xwiki/lesscss/LessCompilerScriptServiceTest.java
+Starting at line 365 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-script/src/test/java/org/xwiki/lesscss/LessCompilerScriptServiceTest.java
+
+    public void clearCacheWithoutRights() throws Exception
+    {
+        // Mocks
+        XWikiDocument doc = mock(XWikiDocument.class);
+        DocumentReference authorReference = new DocumentReference("wiki", "Space", "User");
+        when(xcontext.getDoc()).thenReturn(doc);
+        when(doc.getAuthorReference()).thenReturn(authorReference);
+        DocumentReference currentDocReference = new DocumentReference("wiki", "Space", "Page");
+        when(doc.getDocumentReference()).thenReturn(currentDocReference);
+
+        when(authorizationManager.hasAccess(Right.PROGRAM)).thenReturn(false);
+
+        // Tests
+        assertFalse(mocker.getComponentUnderTest().clearCache());
+
+=====================================================================
+Found a 14 line (101 tokens) duplication in the following files: 
+Starting at line 82 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-notifications/src/test/java/org/xwiki/like/templates/RssLikeRecordableEventPageTest.java
+Starting at line 84 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/test/java/org/xwiki/mentions/templates/RssMentionPageTest.java
+
+        testDocument.setSyntax(Syntax.XWIKI_2_1);
+        this.oldcore.getSpyXWiki().saveDocument(testDocument, this.context);
+
+        // Mock the user's name.
+        when(this.oldcore.getSpyXWiki().getPlainUserName(USER_REFERENCE, this.context)).thenReturn("First & Name");
+
+        // Mock date formatting to avoid issues with timezones.
+        Date mockDate = mock(Date.class);
+        when(this.oldcore.getSpyXWiki().formatDate(mockDate, null, this.context)).thenReturn("<formattedDate>");
+
+        Event testEvent = new DefaultEvent();
+        testEvent.setDate(mockDate);
+        testEvent.setUser(USER_REFERENCE);
+        testEvent.setDocument(TEST_DOCUMENT_REFERENCE);
+
+=====================================================================
+Found a 9 line (101 tokens) duplication in the following files: 
+Starting at line 193 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 283 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 333 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 389 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 434 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 842 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 889 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 936 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+Starting at line 999 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+
+        when(this.queryService.hql(any())).thenReturn(this.query);
+        when(this.query.setLimit(anyInt())).thenReturn(this.query);
+        when(this.query.setOffset(anyInt())).thenReturn(this.query);
+        when(this.query.bindValues(any(Map.class))).thenReturn(this.query);
+        when(this.query.count()).thenReturn(1L);
+
+        renderPage();
+
+        verify(this.queryService).hql(
+
+=====================================================================
+Found a 9 line (101 tokens) duplication in the following files: 
+Starting at line 144 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/export/DocumentSelectionResolverTest.java
+Starting at line 211 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/export/DocumentSelectionResolverTest.java
+
+        when(this.request.getParameterValues("pages")).thenReturn(new String[] {"Shape.%"});
+
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery("where (doc.fullName like ?1)", Query.HQL)).thenReturn(query);
+        when(query.setWiki("test")).thenReturn(query);
+        when(query.bindValues(any(List.class))).thenReturn(query);
+
+        DocumentReference circleReference = new DocumentReference("test", Arrays.asList("Shape", "2D"), "Circle");
+        when(query.execute()).thenReturn(Collections.singletonList(circleReference));
+
+=====================================================================
+Found a 12 line (101 tokens) duplication in the following files: 
+Starting at line 443 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 508 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 552 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 596 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 656 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void update() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a terminal document to another terminal document.
+        DocumentReference oldLinkTarget = new DocumentReference("wiki", "A", "B");
+
+=====================================================================
+Found a 11 line (101 tokens) duplication in the following files: 
+Starting at line 154 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/importer/OfficeAttachmentImporterTest.java
+Starting at line 178 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/importer/OfficeAttachmentImporterTest.java
+
+        when(this.documentAccessBridge.getAttachmentContent(ATTACHMENT_REFERENCE)).thenReturn(attachmentContent);
+
+        XDOMOfficeDocument xdomOfficeDocument = mock(XDOMOfficeDocument.class);
+        when(documentBuilder.build(attachmentContent, "my.doc", ATTACHMENT_REFERENCE.getDocumentReference(), true))
+            .thenReturn(xdomOfficeDocument);
+        when(xdomOfficeDocument.getArtifactsMap()).thenReturn(Collections.emptyMap());
+        when(xdomOfficeDocument.getContentAsString("annotatedxhtml/1.0")).thenReturn("test");
+
+        Map<String, Object> parameters = Collections.singletonMap("filterStyles", "true");
+        assertEquals("test", officeAttachmentImporter.toHTML(ATTACHMENT_REFERENCE, parameters));
+    }
+
+=====================================================================
+Found a 13 line (100 tokens) duplication in the following files: 
+Starting at line 641 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+Starting at line 663 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+
+            assertEquals(currentMajor + ".2", historyPane.getCurrentVersion());
+
+            // Check that the page remained with rights unchanged
+            setup.gotoPage(xwikiPreferences, "edit", "editor=object");
+            objectEditPage = new ObjectEditPage();
+            rightObjects = objectEditPage.getObjectsOfClass("XWiki.XWikiGlobalRights", false);
+            rightObject = rightObjects.get(rightObjects.size() - 1);
+            rightObject.displayObject();
+            assertEquals(deleteVersionTestUser, rightObject.getFieldValue(rightObject.byPropertyName("users")));
+            assertEquals("programming", rightObject.getFieldValue(rightObject.byPropertyName("levels")));
+            assertEquals("0", rightObject.getFieldValue(rightObject.byPropertyName("allow")));
+
+            setup.gotoPage(xwikiPreferences, "view", "viewer=history");
+
+=====================================================================
+Found a 13 line (100 tokens) duplication in the following files: 
+Starting at line 150 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/test/java/org/xwiki/invitation/InvitationCommonPageTest.java
+Starting at line 189 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/test/java/org/xwiki/invitation/InvitationCommonPageTest.java
+
+        invitationConfigXObject.set("from_address", "<script>console.log('from_address')</script>", this.context);
+        this.xwiki.saveDocument(hopefullyNonExistantSpaceDoc, this.context);
+
+        this.request.put("test", "1");
+
+        XWikiDocument invitationCommonDoc = loadPage(INVITATION_COMMON_REFERENCE);
+        Document document = Jsoup.parse(invitationCommonDoc.getRenderedContent(this.context));
+
+        assertEquals("testLoadInvitationConfig", document.selectFirst(".infomessage").text());
+        Element firstErrorMessage = document.selectFirst(".errormessage");
+        assertEquals("Config map too small", firstErrorMessage.text());
+        Element secondErrorMessage = document.select(".errormessage").get(1);
+        assertEquals("form_address incorrect, expecting \"no-reply@localhost.localdomain\" "
+
+=====================================================================
+Found a 10 line (100 tokens) duplication in the following files: 
+Starting at line 140 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/factory/usersandgroups/UsersAndGroupsMimeMessageIteratorTest.java
+Starting at line 505 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/plugin/rightsmanager/ReferenceUserIteratorTest.java
+
+    private void setUpUserPageMocks(DocumentReference userReference, String email) throws Exception
+    {
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.isNew()).thenReturn(false);
+        when(document.getDocumentReference()).thenReturn(userReference);
+        BaseObject baseObject = mock(BaseObject.class);
+        when(document.getXObject(
+            new EntityReference("XWikiUsers", EntityType.DOCUMENT, new EntityReference("XWiki", EntityType.SPACE))))
+            .thenReturn(baseObject);
+        when(this.xwiki.getDocument(userReference, this.xwikiContext)).thenReturn(document);
+
+=====================================================================
+Found a 11 line (100 tokens) duplication in the following files: 
+Starting at line 59 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/AbstractDocumentMentionsAnalyzerTest.java
+Starting at line 72 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/AbstractDocumentMentionsAnalyzerTest.java
+
+    void findDisplayStyleStyleMissing()
+    {
+        MacroBlock mention0 = new MacroBlock("mention", emptyMap(), true);
+        MacroBlock mention1 = new MacroBlock("mention", emptyMap(), true);
+        mention1.setParameter("reference", "test");
+        MacroBlock mention2 = new MacroBlock("mention", emptyMap(), true);
+        mention2.setParameter("reference", "test");
+        mention2.setParameter("anchor", "anchor");
+        DisplayStyle actual = this.analyzer.findDisplayStyle(asList(mention0, mention1, mention2), "test", "anchor");
+        assertEquals(DisplayStyle.FULL_NAME, actual);
+    }
+
+=====================================================================
+Found a 12 line (100 tokens) duplication in the following files: 
+Starting at line 189 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+Starting at line 269 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+Starting at line 349 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsWatchResourceTest.java
+
+    void watchPageWiki() throws Exception
+    {
+        DocumentReference userDocReference = new DocumentReference("xwiki", "XWiki", "User");
+        when(this.context.getUserReference()).thenReturn(userDocReference);
+        UserReference userReference = mock(UserReference.class);
+        when(this.userReferenceResolver.resolve(userDocReference)).thenReturn(userReference);
+        String wikiName = "fooWiki";
+        WikiReference wikiReference = new WikiReference(wikiName);
+        WatchedLocationReference watchedLocationReference = mock(WatchedLocationReference.class);
+        when(this.watchedEntityFactory.createWatchedLocationReference(wikiReference))
+            .thenReturn(watchedLocationReference);
+        when(this.watchedEntitiesManager.watch(watchedLocationReference, userReference)).thenReturn(true);
+
+=====================================================================
+Found a 14 line (100 tokens) duplication in the following files: 
+Starting at line 56 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/PreferenceDateNotificationFilterTest.java
+Starting at line 110 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/PreferenceDateNotificationFilterTest.java
+
+    void shouldFilterEvent()
+    {
+        Event event = mock(Event.class);
+        NotificationPreference pref1 = mock(NotificationPreference.class);
+        NotificationPreference pref2 = mock(NotificationPreference.class);
+        String eventType = "myEventType";
+        when(event.getType()).thenReturn(eventType);
+
+        // pref1 will be discarded
+        when(pref1.getProperties()).thenReturn(Collections.emptyMap());
+        when(pref2.getProperties())
+            .thenReturn(Collections.singletonMap(NotificationPreferenceProperty.EVENT_TYPE, eventType));
+
+        when(event.getDate()).thenReturn(new Date(41));
+
+=====================================================================
+Found a 12 line (100 tokens) duplication in the following files: 
+Starting at line 66 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AverageRatingProtectionListenerTest.java
+Starting at line 104 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AverageRatingProtectionListenerTest.java
+
+        when(ratingObject1.getNumber()).thenReturn(1);
+        BaseObject ratingObject2 = mock(BaseObject.class);
+        when(ratingObject2.getNumber()).thenReturn(2);
+        BaseObject ratingObject3 = mock(BaseObject.class);
+        when(ratingObject3.getNumber()).thenReturn(3);
+
+        BaseObject previousObject1 = mock(BaseObject.class);
+        BaseObject previousObject2 = mock(BaseObject.class);
+
+        when(this.observationContext.isIn(new UpdatingAverageRatingEvent())).thenReturn(false);
+        when(sourceDoc.getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
+            .thenReturn(Arrays.asList(ratingObject1, ratingObject2, ratingObject3));
+
+=====================================================================
+Found a 10 line (100 tokens) duplication in the following files: 
+Starting at line 257 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/RealtimeWYSIWYGEditorIT.java
+Starting at line 280 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/RealtimeWYSIWYGEditorIT.java
+
+        CoeditorElement self = secondEditPage.getToolbar().waitForCoeditor(firstCoeditorId);
+        assertTrue(self.isDisplayed());
+        // The name is not visible when the user is displayed directly on the toolbar.
+        assertEquals("", self.getName());
+        assertEquals("xwiki:XWiki.John", self.getReference());
+        assertTrue(setup.getURL(new DocumentReference("xwiki", "XWiki", "John")).endsWith(self.getURL()));
+        assertTrue(self.getAvatarURL().contains("noavatar.png"), "Unexpected avatar URL: " + self.getAvatarURL());
+        assertEquals("John", self.getAvatarHint());
+        assertEquals("Jo", self.getAbbreviation());
+        assertEquals(2, secondEditPage.getToolbar().getVisibleCoeditors().size());
+
+=====================================================================
+Found a 12 line (100 tokens) duplication in the following files: 
+Starting at line 508 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 720 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+Starting at line 822 of /Users/shibinkoshy/xwiki-platform/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+
+    void renameImage() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
+        XWikiDocument document = mock(XWikiDocument.class);
+        DocumentAuthors authors = mock(DocumentAuthors.class);
+        when(document.getAuthors()).thenReturn(authors);
+        when(this.xcontext.getWiki().getDocument(documentReference, this.xcontext)).thenReturn(document);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        // From a terminal document to another terminal document.
+        DocumentReference oldImageTarget = new DocumentReference("wiki", "A", "B");
+

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-storage/src/main/java/org/xwiki/mail/script/DeprecatedMailStorageScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-storage/src/main/java/org/xwiki/mail/script/DeprecatedMailStorageScriptService.java
@@ -20,35 +20,26 @@
 package org.xwiki.mail.script;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Provider;
 import javax.inject.Singleton;
-import javax.mail.Session;
-import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.mail.MailContentStore;
 import org.xwiki.mail.MailResender;
 import org.xwiki.mail.MailStatus;
 import org.xwiki.mail.MailStatusResult;
-import org.xwiki.mail.MailStatusStore;
-import org.xwiki.mail.MailStorageConfiguration;
 import org.xwiki.mail.MailStoreException;
 import org.xwiki.mail.internal.DefaultMailResult;
-import org.xwiki.security.authorization.ContextualAuthorizationManager;
-import org.xwiki.security.authorization.Right;
-
-import com.xpn.xwiki.XWikiContext;
 
 /**
  * Expose Mail Storage API to scripts.
+ * <p>
+ * This deprecated service delegates to {@link MailStorageScriptService} for all shared functionality,
+ * only overriding what differs (error key and legacy resend behavior).
  *
  * @version $Id$
  * @since 6.4M3
@@ -58,7 +49,7 @@ import com.xpn.xwiki.XWikiContext;
 @Named("mailstorage")
 @Singleton
 @Deprecated
-public class DeprecatedMailStorageScriptService extends AbstractMailScriptService
+public class DeprecatedMailStorageScriptService extends MailStorageScriptService
 {
     /**
      * The key under which the last encountered error is stored in the current execution context.
@@ -66,65 +57,8 @@ public class DeprecatedMailStorageScriptService extends AbstractMailScriptServic
     private static final String ERROR_KEY = "scriptservice.mailstorage.error";
 
     @Inject
-    @Named("filesystem")
-    private MailContentStore mailContentStore;
-
-    @Inject
-    @Named("database")
-    private MailStatusStore mailStatusStore;
-
-    @Inject
-    private Provider<XWikiContext> xwikiContextProvider;
-
-    @Inject
-    private ContextualAuthorizationManager authorizationManager;
-
-    @Inject
-    private MailStorageConfiguration storageConfiguration;
-
-    @Inject
     @Named("database")
     private MailResender mailResender;
-
-    /**
-     * Resend the serialized MimeMessage synchronously.
-     *
-     * @param batchId the name of the directory that contains serialized MimeMessage
-     * @param uniqueMessageId the unique id of the serialized MimeMessage
-     * @return the result and status of the send batch; null if an error occurred when getting the message from the
-     *         store
-     */
-    public ScriptMailResult resend(String batchId, String uniqueMessageId)
-    {
-        ScriptMailResult result = resendAsynchronously(batchId, uniqueMessageId);
-        if (result != null) {
-            // Wait for the message to have been resent before returning
-            result.getStatusResult().waitTillProcessed(Long.MAX_VALUE);
-        }
-        return result;
-    }
-
-    /**
-     * Resend the serialized MimeMessage asynchronously.
-     *
-     * @param batchId the name of the directory that contains serialized MimeMessage
-     * @param uniqueMessageId the unique id of the serialized MimeMessage
-     * @return the result and status of the send batch; null if an error occurred when getting the message from the
-     *         store
-     * @since 9.3RC1
-     */
-    public ScriptMailResult resendAsynchronously(String batchId, String uniqueMessageId)
-    {
-        try {
-            MailStatusResult statusResult = this.mailResender.resendAsynchronously(batchId, uniqueMessageId);
-            ScriptMailResult scriptMailResult = new ScriptMailResult(new DefaultMailResult(batchId), statusResult);
-            return scriptMailResult;
-        } catch (MailStoreException e) {
-            // Save the exception for reporting through the script services's getLastError() API
-            setError(e);
-            return null;
-        }
-    }
 
     /**
      * Resends all mails matching the passed filter map.
@@ -136,6 +70,7 @@ public class DeprecatedMailStorageScriptService extends AbstractMailScriptServic
      *         from the store
      * @since 9.3RC1
      */
+    @Override
     public List<ScriptMailResult> resendAsynchronously(Map<String, Object> filterMap, int offset, int count)
     {
         List<Pair<MailStatus, MailStatusResult>> results;
@@ -153,166 +88,6 @@ public class DeprecatedMailStorageScriptService extends AbstractMailScriptServic
                 new DefaultMailResult(result.getLeft().getBatchId()), result.getRight()));
         }
         return scriptResults;
-    }
-
-    /**
-     * Load message status for the message matching the given message Id.
-     *
-     * @param uniqueMessageId the unique identifier of the message.
-     * @return the loaded {@link org.xwiki.mail.MailStatus} or null if not allowed or an error happens
-     * @since 7.1M2
-     */
-    public MailStatus load(String uniqueMessageId)
-    {
-        // Note: We don't need to check permissions since the caller already needs to know the message id
-        // to be able to call this method and for it to have any effect.
-
-        try {
-            return this.mailStatusStore.load(uniqueMessageId);
-        } catch (MailStoreException e) {
-            // Save the exception for reporting through the script services's getLastError() API
-            setError(e);
-            return null;
-        }
-    }
-
-    /**
-     * Loads all message statuses matching the passed filters.
-     *
-     * @param filterMap the map of Mail Status parameters to match (e.g. "status", "wiki", "batchId", etc)
-     * @param offset the number of rows to skip (0 means don't skip any row)
-     * @param count the number of rows to return. If 0 then all rows are returned
-     * @param sortField the name of the field used to order returned status
-     * @param sortAscending when true, sort is done in ascending order of sortField, else in descending order
-     * @return the loaded {@link org.xwiki.mail.MailStatus} instances or null if not allowed or an error happens
-     * @since 7.1M2
-     */
-    public List<MailStatus> load(Map<String, Object> filterMap, int offset, int count, String sortField,
-        boolean sortAscending)
-    {
-        // Only admins are allowed
-        if (this.authorizationManager.hasAccess(Right.ADMIN)) {
-            try {
-                return this.mailStatusStore.load(normalizeFilterMap(filterMap), offset, count,
-                    sortField, sortAscending);
-            } catch (MailStoreException e) {
-                // Save the exception for reporting through the script services's getLastError() API
-                setError(e);
-                return null;
-            }
-        } else {
-            // Save the exception for reporting through the script services's getLastError() API
-            setError(new MailStoreException("You need Admin rights to load mail statuses"));
-            return null;
-        }
-    }
-
-    /**
-     * Count the number of message statuses matching the passed filters.
-     *
-     * @param filterMap the map of Mail Status parameters to match (e.g. "status", "wiki", "batchId", etc)
-     * @return the number of mail statuses or 0 if not allowed or an error happens
-     */
-    public long count(Map<String, Object> filterMap)
-    {
-        // Only admins are allowed
-        if (this.authorizationManager.hasAccess(Right.ADMIN)) {
-            try {
-                return this.mailStatusStore.count(normalizeFilterMap(filterMap));
-            } catch (MailStoreException e) {
-                // Save the exception for reporting through the script services's getLastError() API
-                setError(e);
-                return 0;
-            }
-        } else {
-            // Save the exception for reporting through the script services's getLastError() API
-            setError(new MailStoreException("You need Admin rights to count mail statuses"));
-            return 0;
-        }
-    }
-
-    /**
-     * Delete all messages from a batch (both the statuses in the database and the serialized messages on the file
-     * system).
-     *
-     * @param batchId the id of the batch for which to delete all messages
-     */
-    public void delete(String batchId)
-    {
-        // Note: We don't need to check permissions since the call to load() will do that anyway.
-
-        Map<String, Object> filterMap = Collections.<String, Object>singletonMap("batchId", batchId);
-        List<MailStatus> statuses = load(filterMap, 0, 0, null, false);
-        if (statuses != null) {
-            for (MailStatus status : statuses) {
-                delete(batchId, status.getMessageId());
-            }
-        }
-    }
-
-    /**
-     * Delete all messages having a status in the database and their serialized messages on the file system.
-     *
-     * @since 9.4RC1
-     */
-    public void deleteAll()
-    {
-        // Note: We don't need to check permissions since the call to load() will do that anyway.
-
-        List<MailStatus> statuses = load(Collections.emptyMap(), 0, 0, null, false);
-        if (statuses != null) {
-            for (MailStatus status : statuses) {
-                delete(status.getBatchId(), status.getMessageId());
-            }
-        }
-    }
-
-    /**
-     * Delete a message (both the status in the database and the serialized messages on the file system).
-     *
-     * @param batchId the id of the batch for the message to delete
-     * @param uniqueMessageId the unique id of the message to delete
-     */
-    public void delete(String batchId, String uniqueMessageId)
-    {
-        // Note: We don't need to check permissions since the caller already needs to know the batch id and mail id
-        // to be able to call this method and for it to have any effect.
-
-        try {
-            // Step 1: Delete mail status from store
-            this.mailStatusStore.delete(uniqueMessageId, Collections.<String, Object>emptyMap());
-            // Step 2: Delete any matching serialized mail
-            this.mailContentStore.delete(batchId, uniqueMessageId);
-        } catch (MailStoreException e) {
-            // Save the exception for reporting through the script services's getLastError() API
-            setError(e);
-        }
-    }
-
-    /**
-     * @return the configuration for the Mail Storage
-     */
-    public MailStorageConfiguration getConfiguration()
-    {
-        return this.storageConfiguration;
-    }
-
-    private Map<String, Object> normalizeFilterMap(Map<String, Object> filterMap)
-    {
-        // Force the wiki to be the current wiki to prevent any subwiki to see the list of mail statuses from other
-        // wikis
-        Map<String, Object> normalizedMap = new HashMap<>(filterMap);
-        XWikiContext xwikiContext = this.xwikiContextProvider.get();
-        if (!xwikiContext.isMainWiki()) {
-            normalizedMap.put("wiki", xwikiContext.getWikiId());
-        }
-        return normalizedMap;
-    }
-
-    private MimeMessage loadMessage(Session session, String batchId, String mailId) throws MailStoreException
-    {
-        MimeMessage message = this.mailContentStore.load(session, batchId, mailId);
-        return message;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/script/MailStorageScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/script/MailStorageScriptService.java
@@ -298,7 +298,7 @@ public class MailStorageScriptService extends AbstractMailScriptService
         return this.storageConfiguration;
     }
 
-    private Map<String, Object> normalizeFilterMap(Map<String, Object> filterMap)
+    protected Map<String, Object> normalizeFilterMap(Map<String, Object> filterMap)
     {
         // Force the wiki to be the current wiki to prevent any subwiki to see the list of mail statuses from other
         // wikis
@@ -310,7 +310,7 @@ public class MailStorageScriptService extends AbstractMailScriptService
         return normalizedMap;
     }
 
-    private MimeMessage loadMessage(Session session, String batchId, String mailId) throws MailStoreException
+    protected MimeMessage loadMessage(Session session, String batchId, String mailId) throws MailStoreException
     {
         MimeMessage message = this.mailContentStore.load(session, batchId, mailId);
         return message;


### PR DESCRIPTION
## Summary
CPD detected a 161-line (502 tokens) duplication between DeprecatedMailStorageScriptService and MailStorageScriptService.

## Changes
- DeprecatedMailStorageScriptService now extends MailStorageScriptService instead of AbstractMailScriptService, removing all duplicated methods (load, count, delete, deleteAll, normalizeFilterMap, loadMessage, getConfiguration, resend, resendAsynchronously)
- Changed normalizeFilterMap() and loadMessage() from private to protected in MailStorageScriptService to support inheritance
- Only ERROR_KEY and legacy resendAsynchronously(filterMap) retained in the deprecated class

## Result
- 232 lines of duplicated code removed
- 7 lines added
- Detected by PMD CPD with --minimum-tokens 100