### PR TITLE
fix: force commons-collections 3.2.2 to remediate CVE-2015-7501

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,14 @@
   <!-- Dependency Management that are used in platform and in subprojects too (like xwiki-enterprise) -->
   <dependencyManagement>
     <dependencies>
+            <!-- Security fix: Force commons-collections to 3.2.2 to remediate CVE-2015-7501
+           (Deserialization of Untrusted Data, CWE-502, CVSS 9.8 Critical)
+           Transitive dependency pulled in via securityfilter:2.0 -->
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
       <!-- Standard dependencies used in several modules -->
       <dependency>
         <groupId>com.mchange</groupId>


### PR DESCRIPTION
## Summary
Forces `commons-collections` to version `3.2.2` via Maven `dependencyManagement` 
in the root `pom.xml` to remediate CVE-2015-7501.

## Vulnerability Details
- **Tool:** SNYK
- **CVE:** CVE-2015-7501
- **CWE:** CWE-502 (Deserialization of Untrusted Data)
- **Severity:** Critical (CVSS 9.8)
- **Exploit Maturity:** Mature (actively exploited)

## Root Cause
`securityfilter:2.0` pulls in `commons-collections:3.1` as a transitive 
dependency, which allows arbitrary Java code execution via deserialization 
over JMX, RMI, or EJB.

## Fix
Added `commons-collections:3.2.2` to root `pom.xml` dependencyManagement 
to force the safe version across all modules.

Closes #12
